### PR TITLE
Improve self-healing robustness and fix prompt/context gaps

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -503,12 +503,41 @@ The self-healing system in `selfHealing.js` uses a strategy waterfall:
 6. locator(CSS selector)                     ← least semantic, last resort
 ```
 
-On every test run, the winning strategy index is recorded in `db.healingHistory` keyed by `"<testId>::<action>::<label>"`. The next run loads that hint and tries the winning strategy first via `getHealingHint()`.
+### Runtime helpers
 
-When adding new selector strategies:
+All interactions in generated tests are routed through safe wrappers:
+
+| Helper | Purpose |
+|---|---|
+| `safeClick(page, text)` | Click by accessible name/text |
+| `safeDblClick(page, text)` | Double-click |
+| `safeHover(page, text)` | Hover (menus, tooltips) |
+| `safeFill(page, label, value)` | Fill input fields |
+| `safeSelect(page, label, value)` | Select/dropdown (preserves object/array values) |
+| `safeCheck(page, label)` | Check checkbox/radio |
+| `safeUncheck(page, label)` | Uncheck checkbox/radio |
+| `safeExpect(page, expect, text, role?)` | Visibility assertions |
+
+`applyHealingTransforms()` rewrites raw Playwright calls (e.g. `page.click(...)`, `page.locator(...).check()`) into the safe helpers. When adding new transform rules, ensure **every** Playwright call pattern listed in `SELF_HEALING_PROMPT_RULES` has a corresponding regex in `applyHealingTransforms`.
+
+### Healing history & versioned scoping
+
+On every test run, the winning strategy index is recorded in `db.healingHistory`. Keys are **versioned** by test code revision: `"<testId>@v<codeVersion>::<action>::<label>"`. This ensures stale hints from old code versions don't pollute current runs. The repository layer (`healingRepo.getByTestId`) reads both versioned and legacy (unversioned) keys for backward compatibility.
+
+### Fail-count cap
+
+Hints that have failed `≥ HEALING_HINT_MAX_FAILS` (default 3, env-configurable) consecutive times are skipped by both `getHealingHint()` and `getHealingHistoryForTest()`. This prevents the runtime from retrying strategies that are known-broken.
+
+### Visibility wait cap
+
+The `firstVisible()` helper caps its `waitFor` timeout at `HEALING_VISIBLE_WAIT_CAP` (default 1200ms, env-configurable) to avoid slow waterfalls when a strategy doesn't match. The full retry loop still provides multiple attempts.
+
+### Adding new selector strategies
+
 - Add them to the `strategies` array in the helper code returned by `getSelfHealingHelperCode()`.
 - Keep strategies ordered from most-semantic (ARIA) to least-semantic (CSS), so the adaptive hint system consistently learns the best approach.
-- Do not change the index of existing strategies without running a DB migration that resets all `healingHistory` entries.
+- Bump `STRATEGY_VERSION` in `selfHealing.js` when reordering or removing strategies — hints from older versions are automatically ignored.
+- Do not change the healing key schema (`<testId>@v<version>::<action>::<label>`) without a migration strategy — existing DB records will silently stop matching.
 
 ---
 
@@ -625,12 +654,18 @@ Before submitting any PR that touches auth, routes, or data handling, verify:
 - [ ] Any HTML rendered via `dangerouslySetInnerHTML` is sanitised — escape all user/AI-generated content before insertion. Use `escapeHtml()` on raw text before applying markdown/formatting transforms.
 - [ ] Error responses to clients never leak internal details (stack traces, SDK error messages, API key validation failures). Return generic messages for 5xx errors.
 
+### Resolved Security Items
+
+The following have been implemented and are no longer open:
+
+- **Rate limiting** ✅: Per-endpoint rate limiters are configured in `routes/auth.js` — separate buckets for login (10/IP/15 min), forgot-password (5), and reset-password (5). Uses `trust proxy` for correct IP detection behind nginx.
+- **Content-Security-Policy** ✅: Helmet CSP is fully enabled in `middleware/appSetup.js` with explicit directives (`default-src 'self'`, `script-src 'self' 'unsafe-inline'`, `connect-src 'self'`, `frame-ancestors 'none'`, etc.). Tighten `'unsafe-inline'` to nonce-based in production.
+- **Reset token exposure** ✅: The forgot-password endpoint only returns the reset token in the response when `ENABLE_DEV_RESET_TOKENS=true` is explicitly set. Absence of a production flag is no longer sufficient to leak tokens.
+
 ### Known Security Gaps (TODO)
 
 The following are **not yet implemented** but should be addressed before production:
 
-- **Rate limiting**: No `express-rate-limit` or equivalent middleware is configured. Endpoints that trigger expensive operations (AI calls, crawl, test execution) are unprotected against abuse.
-- **Content-Security-Policy**: Helmet is enabled but CSP is explicitly disabled (`contentSecurityPolicy: false` in `middleware/appSetup.js`). The SPA needs a proper CSP policy before production deployment.
 - **Artifact authentication**: The `/artifacts` static route is **not behind `requireAuth`**. Screenshots, videos, and traces are served publicly. Artifact filenames contain random run IDs which provide obscurity but not security. To add auth, implement `?token=` query param validation (same pattern as SSE/export endpoints) and update all frontend artifact URLs.
 - **Error tracking**: No external error tracking (Sentry, etc.) is configured. Errors are only visible in server logs and browser console.
 
@@ -656,6 +691,12 @@ The following are **not yet implemented** but should be addressed before product
 | `LLM_MAX_BACKOFF_MS` | No | `30000` | Max computed backoff delay (server Retry-After capped at 2×) |
 | `BROWSER_TEST_TIMEOUT` | No | `120000` | Per-test timeout guard — aborts hung browser tests (ms) |
 | `NODE_ENV` | No | `development` | Enables dev-only seed endpoint when not `production` |
+| `HEALING_ELEMENT_TIMEOUT` | No | `5000` | Per-strategy element wait timeout (ms) |
+| `HEALING_RETRY_COUNT` | No | `3` | Number of retry attempts per self-healing action |
+| `HEALING_RETRY_DELAY` | No | `400` | Delay between retries (ms) |
+| `HEALING_HINT_MAX_FAILS` | No | `3` | Skip healing hints that have failed this many consecutive times |
+| `HEALING_VISIBLE_WAIT_CAP` | No | `1200` | Max `waitFor` timeout per strategy in `firstVisible` (ms) |
+| `ENABLE_DEV_RESET_TOKENS` | No | `false` | When `"true"`, forgot-password response includes the reset token (dev/test only) |
 
 ---
 
@@ -725,7 +766,7 @@ The frontend follows a clear separation of concerns between pages:
 - **Do not import LLM SDKs directly** outside of `aiProvider.js`.
 - **Do not call `fetch()` directly** in frontend components; use `api.js`. Streaming endpoints that bypass `req()` must still handle 401 via `handleUnauthorized()`.
 - **Do not store secrets in code or commit `.env` files.**
-- **Do not change the `healingHistory` key schema** without a migration strategy — existing DB records will silently stop matching.
+- **Do not change the `healingHistory` key schema** (`<testId>@v<version>::<action>::<label>`) without a migration strategy — existing DB records will silently stop matching. The repository layer reads both versioned and legacy keys, but new writes always use the versioned format.
 - **Do not add polling** to the frontend for run status — use the existing SSE infrastructure (`useRunSSE`).
 - **Do not add a new test framework** to either package. Backend tests use `node:assert/strict`; keep it that way.
 - **Do not write raw SQL in route handlers** — always go through repository modules in `database/repositories/`. Do not use `getDb()` for writes — it returns a read-only snapshot.

--- a/backend/src/database/migrations/002_healing_strategy_version.sql
+++ b/backend/src/database/migrations/002_healing_strategy_version.sql
@@ -1,0 +1,10 @@
+-- Migration 002: strategyVersion column on healing_history
+--
+-- This column is added lazily by healingRepo.ensureStrategyVersionColumn()
+-- (called from both set() and getByTestId()) because SQLite's ALTER TABLE
+-- ADD COLUMN does not support IF NOT EXISTS, making a pure-SQL migration
+-- unsafe on databases where the lazy migration already ran.
+--
+-- This file is intentionally a no-op so the migration number is reserved
+-- and the schema_migrations table documents that the column exists.
+-- The actual DDL lives in healingRepo.js:ensureStrategyVersionColumn().

--- a/backend/src/database/repositories/healingRepo.js
+++ b/backend/src/database/repositories/healingRepo.js
@@ -89,8 +89,11 @@ export function getByTestId(testId) {
   // Build a query with the right number of OR clauses
   const uniquePatterns = [...new Set(patterns)];
   const whereClauses = uniquePatterns.map(() => "key LIKE ?").join(" OR ");
+  // ORDER BY ensures that when multiple versions exist for the same
+  // action::label, the versioned entry (strategyVersion IS NOT NULL)
+  // is processed last and wins the collision in the flat result dict.
   const rows = db.prepare(
-    `SELECT * FROM healing_history WHERE ${whereClauses}`
+    `SELECT * FROM healing_history WHERE ${whereClauses} ORDER BY strategyVersion ASC NULLS FIRST`
   ).all(...uniquePatterns);
 
   const result = {};

--- a/backend/src/database/repositories/healingRepo.js
+++ b/backend/src/database/repositories/healingRepo.js
@@ -73,6 +73,12 @@ export function getAllAsDict() {
  */
 export function getByTestId(testId) {
   const db = getDatabase();
+  // Ensure the strategyVersion column exists before querying — the ORDER BY
+  // clause references it, but the column is not in the initial schema (001).
+  // On databases where set() has never been called, the lazy migration in
+  // ensureStrategyVersionColumn() hasn't run yet and the query would crash
+  // with "no such column: strategyVersion".
+  ensureStrategyVersionColumn(db);
 
   // Strip the @vN suffix (if present) to derive the base test ID so we
   // can also query legacy keys stored before versioned scopes existed.

--- a/backend/src/database/repositories/healingRepo.js
+++ b/backend/src/database/repositories/healingRepo.js
@@ -20,20 +20,31 @@ export function get(key) {
  * @param {string} key
  * @param {Object} entry — { strategyIndex, succeededAt, failCount }
  */
+// Lazy migration flag — ensures the strategyVersion column exists before first use.
+let _migrated = false;
+function ensureStrategyVersionColumn(db) {
+  if (_migrated) return;
+  try { db.prepare("ALTER TABLE healing_history ADD COLUMN strategyVersion INTEGER").run(); } catch { /* already exists */ }
+  _migrated = true;
+}
+
 export function set(key, entry) {
   const db = getDatabase();
+  ensureStrategyVersionColumn(db);
   db.prepare(`
-    INSERT INTO healing_history (key, strategyIndex, succeededAt, failCount)
-    VALUES (@key, @strategyIndex, @succeededAt, @failCount)
+    INSERT INTO healing_history (key, strategyIndex, succeededAt, failCount, strategyVersion)
+    VALUES (@key, @strategyIndex, @succeededAt, @failCount, @strategyVersion)
     ON CONFLICT(key) DO UPDATE SET
       strategyIndex = @strategyIndex,
       succeededAt = @succeededAt,
-      failCount = @failCount
+      failCount = @failCount,
+      strategyVersion = @strategyVersion
   `).run({
     key,
     strategyIndex: entry.strategyIndex ?? -1,
     succeededAt: entry.succeededAt || null,
     failCount: entry.failCount || 0,
+    strategyVersion: entry.strategyVersion ?? null,
   });
 }
 

--- a/backend/src/database/repositories/healingRepo.js
+++ b/backend/src/database/repositories/healingRepo.js
@@ -51,16 +51,37 @@ export function getAllAsDict() {
 
 /**
  * Get all healing entries for a specific test (keys starting with "<testId>::").
- * @param {string} testId
+ *
+ * Accepts both raw test IDs (`"TC-1"`) and versioned scope IDs
+ * (`"TC-1@v2"`).  When a versioned scope is passed we also query the
+ * legacy (unversioned) prefix so that pre-existing healing entries
+ * remain readable after upgrading to versioned scopes.
+ *
+ * @param {string} testId — raw test ID or versioned scope ID
  * @returns {Object<string, Object>} Map of `"action::label"` → entry.
  */
 export function getByTestId(testId) {
   const db = getDatabase();
-  const exactPrefix = `${testId}::`;
-  const versionedPrefix = `${testId}@v`;
+
+  // Strip the @vN suffix (if present) to derive the base test ID so we
+  // can also query legacy keys stored before versioned scopes existed.
+  const baseId = testId.replace(/@v\d+$/, "");
+
+  const patterns = [`${testId}::%`];
+  // When testId already contains @v, also query unversioned legacy keys
+  if (baseId !== testId) {
+    patterns.push(`${baseId}::%`);
+  }
+  // Also query any other versioned keys for this base ID
+  patterns.push(`${baseId}@v%::%`);
+
+  // Build a query with the right number of OR clauses
+  const uniquePatterns = [...new Set(patterns)];
+  const whereClauses = uniquePatterns.map(() => "key LIKE ?").join(" OR ");
   const rows = db.prepare(
-    "SELECT * FROM healing_history WHERE key LIKE ? OR key LIKE ?"
-  ).all(`${exactPrefix}%`, `${versionedPrefix}%`);
+    `SELECT * FROM healing_history WHERE ${whereClauses}`
+  ).all(...uniquePatterns);
+
   const result = {};
   for (const r of rows) {
     const sepIdx = r.key.indexOf("::");
@@ -77,11 +98,10 @@ export function getByTestId(testId) {
 export function deleteByTestIds(testIds) {
   const db = getDatabase();
   const stmt = db.prepare("DELETE FROM healing_history WHERE key LIKE ?");
-  const versionedStmt = db.prepare("DELETE FROM healing_history WHERE key LIKE ?");
   const txn = db.transaction(() => {
     for (const tid of testIds) {
       stmt.run(`${tid}::%`);
-      versionedStmt.run(`${tid}@v%::%`);
+      stmt.run(`${tid}@v%::%`);
     }
   });
   txn();

--- a/backend/src/database/repositories/healingRepo.js
+++ b/backend/src/database/repositories/healingRepo.js
@@ -56,11 +56,16 @@ export function getAllAsDict() {
  */
 export function getByTestId(testId) {
   const db = getDatabase();
-  const prefix = `${testId}::`;
-  const rows = db.prepare("SELECT * FROM healing_history WHERE key LIKE ?").all(`${prefix}%`);
+  const exactPrefix = `${testId}::`;
+  const versionedPrefix = `${testId}@v`;
+  const rows = db.prepare(
+    "SELECT * FROM healing_history WHERE key LIKE ? OR key LIKE ?"
+  ).all(`${exactPrefix}%`, `${versionedPrefix}%`);
   const result = {};
   for (const r of rows) {
-    result[r.key.slice(prefix.length)] = r;
+    const sepIdx = r.key.indexOf("::");
+    if (sepIdx < 0) continue;
+    result[r.key.slice(sepIdx + 2)] = r;
   }
   return result;
 }
@@ -72,9 +77,11 @@ export function getByTestId(testId) {
 export function deleteByTestIds(testIds) {
   const db = getDatabase();
   const stmt = db.prepare("DELETE FROM healing_history WHERE key LIKE ?");
+  const versionedStmt = db.prepare("DELETE FROM healing_history WHERE key LIKE ?");
   const txn = db.transaction(() => {
     for (const tid of testIds) {
       stmt.run(`${tid}::%`);
+      versionedStmt.run(`${tid}@v%::%`);
     }
   });
   txn();

--- a/backend/src/pipeline/assertionEnhancer.js
+++ b/backend/src/pipeline/assertionEnhancer.js
@@ -51,6 +51,7 @@ export function hasNoAssertions(playwrightCode) {
 function hostnameRegex(url) {
   try {
     const h = new URL(url).hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (!h) return "/.+/";
     return `/${h}/i`;
   } catch {
     return "/.+/";

--- a/backend/src/pipeline/assertionEnhancer.js
+++ b/backend/src/pipeline/assertionEnhancer.js
@@ -47,16 +47,25 @@ export function hasNoAssertions(playwrightCode) {
 // The enhancer tries classifiedPage.dominantIntent first, then test.type,
 // then falls back to FALLBACK.
 
+// Helper: extract hostname regex from snapshot URL for loose URL assertions.
+function hostnameRegex(url) {
+  try {
+    const h = new URL(url).hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return `/${h}/i`;
+  } catch {
+    return "/.+/";
+  }
+}
+
 const INTENT_TEMPLATES = {
   AUTH: (snapshot) => `
-  // Assert successful authentication
-  await expect(page).not.toHaveURL(${JSON.stringify(snapshot.url)});
+  // Assert successful authentication — URL should change away from login page
   await expect(page.locator('body')).not.toContainText('Invalid');
   await expect(page.locator('body')).not.toContainText('error');`,
 
   NAVIGATION: (snapshot) => `
   // Assert page loaded correctly
-  await expect(page).toHaveURL(${JSON.stringify(snapshot.url)});
+  await expect(page).toHaveURL(${hostnameRegex(snapshot.url)});
   await expect(page).toHaveTitle(/.+/);
   await expect(page.locator('h1, h2, main').first()).toBeVisible();`,
 
@@ -70,9 +79,9 @@ const INTENT_TEMPLATES = {
   await expect(page.locator('input[type="search"], input[placeholder*="search" i]').first()).toBeVisible();`,
 
   CRUD: (snapshot) => `
-  // Assert action completed
+  // Assert action completed — use flexible matcher for toast/notification text
   await expect(page.locator('body')).not.toContainText('Error');
-  await expect(page.locator('[role="alert"], .alert, .notification, .toast').first()).toBeVisible().catch(() => {});`,
+  await expect(page.locator('[role="alert"], .alert, .notification, .toast').first()).toContainText(/success|saved|created|updated|deleted/i).catch(() => {});`,
 
   CHECKOUT: (snapshot) => `
   // Assert checkout elements visible
@@ -93,12 +102,12 @@ const TYPE_TEMPLATES = {
 
   smoke: (snapshot) => `
   // Smoke check — page loads without errors
-  await expect(page).toHaveURL(${JSON.stringify(snapshot.url)});
+  await expect(page).toHaveURL(${hostnameRegex(snapshot.url)});
   await expect(page).toHaveTitle(/.+/);`,
 
   regression: (snapshot) => `
   // Regression — verify existing content unchanged
-  await expect(page).toHaveURL(${JSON.stringify(snapshot.url)});
+  await expect(page).toHaveURL(${hostnameRegex(snapshot.url)});
   await expect(page).toHaveTitle(/.+/);
   await expect(page.locator('h1, h2, main').first()).toBeVisible();`,
 
@@ -119,12 +128,12 @@ const TYPE_TEMPLATES = {
 
   security: (snapshot) => `
   // Security — verify auth boundary
-  await expect(page).not.toHaveURL(${JSON.stringify(snapshot.url)});
-  await expect(page.locator('body')).not.toContainText('Invalid');`,
+  await expect(page.locator('body')).not.toContainText('Invalid');
+  await expect(page.locator('body')).not.toContainText('error');`,
 
   performance: (snapshot) => `
   // Performance — verify page loads within timeout
-  await expect(page).toHaveURL(${JSON.stringify(snapshot.url)});
+  await expect(page).toHaveURL(${hostnameRegex(snapshot.url)});
   await expect(page).toHaveTitle(/.+/);`,
 };
 
@@ -136,7 +145,18 @@ const FALLBACK_TEMPLATE = (snapshot) => `
 // ── Page load assertion (always included) ────────────────────────────────────
 
 function buildPageLoadAssertion(url, title) {
-  const assertions = [`  await expect(page).toHaveURL(${JSON.stringify(url)});`];
+  // Use a loose hostname-only regex instead of an exact URL string.
+  // Exact URLs break on redirects, query params, geo-variants, and
+  // consent/CAPTCHA interstitials. This matches the STABILITY_RULES guidance.
+  let hostname;
+  try {
+    hostname = new URL(url).hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  } catch {
+    hostname = null;
+  }
+  const assertions = hostname
+    ? [`  await expect(page).toHaveURL(/${hostname}/i);`]
+    : [];
   if (title) {
     const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").slice(0, 30);
     assertions.push(`  await expect(page).toHaveTitle(/${escapedTitle}/i);`);

--- a/backend/src/pipeline/feedbackLoop.js
+++ b/backend/src/pipeline/feedbackLoop.js
@@ -231,11 +231,15 @@ Fix by:
 - Adding await page.waitForLoadState('domcontentloaded') after page.goto()`,
 
     ASSERTION_FAIL: `The assertion failed - the actual value didn't match expected.
+This often happens because the test hard-coded a crawl-time value that changed at runtime.
 Fix by:
-- Using softer matchers: toContainText instead of toHaveText
-- Using regex patterns: /partial match/i
-- Adding proper wait before assertion
-- Asserting on what's actually present on the page`,
+- Using softer matchers: toContainText instead of toHaveText for any text that may vary
+- Using regex patterns for dynamic content: dates (/\\d{4}-\\d{2}-\\d{2}/), IDs (/Order #\\d+/), prices (/\\$[\\d,.]+/), UUIDs (/[a-f0-9-]{36}/)
+- For personalized text (e.g. "Welcome John"), assert only the static label: toContainText('Welcome')
+- For counts that change, use not.toHaveCount(0) instead of toHaveCount(N)
+- For toasts/notifications, use toContainText(/success|saved|created|updated|deleted/i)
+- Adding proper wait before assertion: await expect(locator).toContainText('expected', { timeout: 10000 })
+- Asserting on what's actually present on the page — check the error message for the "received" value`,
 
     UNKNOWN: `The test failed for an unknown reason.
 Rewrite more defensively:
@@ -290,7 +294,9 @@ export function analyzeRunResults(runResults, testMap, snapshotsByUrl) {
 
   // High-priority categories that should be auto-fixed — these are almost always
   // prompt-quality issues rather than real application bugs.
-  const HIGH_PRIORITY_CATEGORIES = new Set(["SELECTOR_ISSUE", "URL_MISMATCH", "TIMEOUT"]);
+  // ASSERTION_FAIL is included because hard-coded crawl-time values (dates, IDs,
+  // counts) are a prompt-quality issue, not a real application regression.
+  const HIGH_PRIORITY_CATEGORIES = new Set(["SELECTOR_ISSUE", "URL_MISMATCH", "TIMEOUT", "ASSERTION_FAIL"]);
 
   for (const result of runResults) {
     stats.total++;

--- a/backend/src/pipeline/feedbackLoop.js
+++ b/backend/src/pipeline/feedbackLoop.js
@@ -21,6 +21,7 @@ import { generateText, parseJSON } from "../aiProvider.js";
 import { throwIfAborted } from "../utils/abortHelper.js";
 import * as testRepo from "../database/repositories/testRepo.js";
 import * as runRepo from "../database/repositories/runRepo.js";
+import { SELF_HEALING_PROMPT_RULES } from "../selfHealing.js";
 
 // ── Failure classification ────────────────────────────────────────────────────
 
@@ -261,6 +262,9 @@ PAGE CONTEXT:
 
 INSTRUCTIONS:
 ${categoryInstructions[failureCategory] || categoryInstructions.UNKNOWN}
+
+SELF-HEALING RULES:
+${SELF_HEALING_PROMPT_RULES}
 
 Return ONLY valid JSON (no markdown):
 {

--- a/backend/src/pipeline/prompts/apiTestPrompt.js
+++ b/backend/src/pipeline/prompts/apiTestPrompt.js
@@ -8,6 +8,7 @@
  * directly and assert on status codes, response shapes, and headers.
  *
  * ### Exports
+ * - {@link formatJsonExample} — `(raw, maxChars?) → string`
  * - {@link buildApiTestPrompt} — `(endpoints, appUrl) → { system, user }`
  */
 
@@ -15,6 +16,18 @@ import { isLocalProvider } from "../../aiProvider.js";
 import { resolveTestCountInstruction } from "../promptHelpers.js";
 import { PROMPT_VERSION } from "./outputSchema.js";
 
+/**
+ * Truncate a JSON request/response body example to fit within a token budget.
+ *
+ * For JSON arrays, incrementally includes elements until `maxChars` is reached.
+ * For JSON objects, incrementally includes keys. Always preserves at least one
+ * element/key so the shape is visible. Non-JSON payloads are sliced with a
+ * `[truncated]` marker.
+ *
+ * @param {string|*} raw           — raw body string (or falsy/non-string passthrough)
+ * @param {number}   [maxChars=1800] — approximate character budget
+ * @returns {string} Truncated JSON or sliced string
+ */
 export function formatJsonExample(raw, maxChars = 1800) {
   if (!raw || typeof raw !== "string") return raw || "";
   if (raw.length <= maxChars) return raw;

--- a/backend/src/pipeline/prompts/apiTestPrompt.js
+++ b/backend/src/pipeline/prompts/apiTestPrompt.js
@@ -20,7 +20,20 @@ function formatJsonExample(raw, maxChars = 1800) {
   if (raw.length <= maxChars) return raw;
   try {
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return JSON.stringify(parsed.slice(0, 10), null, 2);
+    if (Array.isArray(parsed)) {
+      // Incrementally include elements until we exceed maxChars
+      const compact = [];
+      for (const item of parsed) {
+        compact.push(item);
+        if (JSON.stringify(compact, null, 2).length > maxChars) {
+          compact.pop();
+          break;
+        }
+      }
+      // Always include at least one element so the shape is visible
+      if (compact.length === 0 && parsed.length > 0) compact.push(parsed[0]);
+      return JSON.stringify(compact, null, 2);
+    }
     if (parsed && typeof parsed === "object") {
       const compact = {};
       for (const [k, v] of Object.entries(parsed)) {

--- a/backend/src/pipeline/prompts/apiTestPrompt.js
+++ b/backend/src/pipeline/prompts/apiTestPrompt.js
@@ -15,6 +15,30 @@ import { isLocalProvider } from "../../aiProvider.js";
 import { resolveTestCountInstruction } from "../promptHelpers.js";
 import { PROMPT_VERSION } from "./outputSchema.js";
 
+function formatJsonExample(raw, maxChars = 1800) {
+  if (!raw || typeof raw !== "string") return raw || "";
+  if (raw.length <= maxChars) return raw;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return JSON.stringify(parsed.slice(0, 10), null, 2);
+    if (parsed && typeof parsed === "object") {
+      const compact = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        compact[k] = v;
+        const next = JSON.stringify(compact, null, 2);
+        if (next.length > maxChars) {
+          delete compact[k];
+          break;
+        }
+      }
+      return JSON.stringify(compact, null, 2);
+    }
+  } catch {
+    // non-JSON payload; fall through
+  }
+  return `${raw.slice(0, maxChars)}\n... [truncated]`;
+}
+
 /**
  * Build the system + user prompt for API test generation.
  *
@@ -69,10 +93,10 @@ PROMPT VERSION: ${PROMPT_VERSION}`;
       `    Example URL: ${ep.exampleUrls[0] || "N/A"}`,
     ];
     if (ep.requestBodyExample) {
-      lines.push(`    Request body: ${ep.requestBodyExample.slice(0, 500)}`);
+      lines.push(`    Request body: ${formatJsonExample(ep.requestBodyExample)}`);
     }
     if (ep.responseBodyExample) {
-      lines.push(`    Response body: ${ep.responseBodyExample.slice(0, 500)}`);
+      lines.push(`    Response body: ${formatJsonExample(ep.responseBodyExample)}`);
     }
     if (ep.pageUrls.length > 0) {
       lines.push(`    Triggered from: ${ep.pageUrls.join(", ")}`);

--- a/backend/src/pipeline/prompts/apiTestPrompt.js
+++ b/backend/src/pipeline/prompts/apiTestPrompt.js
@@ -15,7 +15,7 @@ import { isLocalProvider } from "../../aiProvider.js";
 import { resolveTestCountInstruction } from "../promptHelpers.js";
 import { PROMPT_VERSION } from "./outputSchema.js";
 
-function formatJsonExample(raw, maxChars = 1800) {
+export function formatJsonExample(raw, maxChars = 1800) {
   if (!raw || typeof raw !== "string") return raw || "";
   if (raw.length <= maxChars) return raw;
   try {

--- a/backend/src/pipeline/prompts/apiTestPrompt.js
+++ b/backend/src/pipeline/prompts/apiTestPrompt.js
@@ -44,6 +44,11 @@ function formatJsonExample(raw, maxChars = 1800) {
           break;
         }
       }
+      // Always include at least one key so the shape is visible
+      if (Object.keys(compact).length === 0 && Object.keys(parsed).length > 0) {
+        const [firstKey, firstVal] = Object.entries(parsed)[0];
+        compact[firstKey] = firstVal;
+      }
       return JSON.stringify(compact, null, 2);
     }
   } catch {

--- a/backend/src/pipeline/prompts/intentPrompt.js
+++ b/backend/src/pipeline/prompts/intentPrompt.js
@@ -134,7 +134,7 @@ STRICT RULES:
 1. ${testCountInstr} — must include BOTH positive AND negative scenarios
 2. Each test validates a REAL user goal or validates graceful failure handling
 3. CRITICAL: Every playwrightCode MUST start with: await page.goto('${snapshot.url}', { waitUntil: 'domcontentloaded', timeout: 30000 }); — use the EXACT URL above, never a placeholder
-4. Read the actual PAGE DATA above (title, headings, elements) and assert against REAL content from that page
+4. Read the actual PAGE DATA above (title, headings, elements) and assert against STRUCTURAL content from that page (headings, labels, button text, form fields). Do NOT hard-code dynamic values (usernames, dates, order IDs, counts, prices) — use regex patterns instead (see DYNAMIC CONTENT rules in system prompt)
 
 ${buildOutputSchemaBlock()}`;
 

--- a/backend/src/pipeline/prompts/outputSchema.js
+++ b/backend/src/pipeline/prompts/outputSchema.js
@@ -40,11 +40,20 @@ export const ASSERTION_RULES = `
 - Every test MUST have at least 2 strong assertions that verify SPECIFIC VISIBLE CONTENT on the page (exact text, element count, field value) — not just that "a page loaded" or "an element exists".
 - STRONG assertions (preferred): toBeVisible() on elements found by specific text/role, toContainText('exact text'), toHaveValue('specific value'), toBeEnabled(), toHaveCount(N). Use toHaveURL() ONLY with a loose hostname-only regex (see STABILITY rule) — never with path or query patterns.
 - WEAK (forbidden): toBeTruthy(), toBeDefined(), toEqual(true).
-- In "playwrightCode", every expect() assertion must check something a user can SEE — a specific heading, a button label, form field content, a list item count, an error message, or a visible text string. Do NOT write assertions that only check "page loaded" or "element exists" without verifying its text or state.`.trim();
+- In "playwrightCode", every expect() assertion must check something a user can SEE — a specific heading, a button label, form field content, a list item count, an error message, or a visible text string. Do NOT write assertions that only check "page loaded" or "element exists" without verifying its text or state.
+- DYNAMIC CONTENT: Page data from the crawl is a snapshot — values like usernames, order IDs, dates, counts, prices, and UUIDs WILL differ at runtime. NEVER hard-code dynamic values in assertions. Instead:
+  ✓ Dates:    toContainText(/\\d{4}-\\d{2}-\\d{2}/) or toContainText(/\\w+ \\d{1,2}, \\d{4}/)
+  ✓ IDs/UUIDs: toHaveAttribute('data-id', /[a-f0-9-]{36}/) or toContainText(/Order #\\d+/)
+  ✓ Counts:   expect(page.locator(...)).not.toHaveCount(0)  — NOT toHaveCount(5)
+  ✓ Prices:   toContainText(/\\$[\\d,.]+/)
+  ✓ Usernames/personalization: assert the LABEL is visible ("Welcome") not the dynamic value ("Welcome John")
+  ✓ Toasts/notifications: toContainText(/success|saved|created|updated|deleted/i) — NOT exact text
+  ✗ NEVER: toHaveText('Welcome John'), toContainText('Order #12345'), toHaveCount(5) on dynamic lists`.trim();
 
 export const STABILITY_RULES = `
 - URL ASSERTIONS: NEVER assert exact URLs or narrow regex patterns on the final URL after navigation. Real-world sites redirect unpredictably (CAPTCHAs, consent pages, geo-redirects, login walls, URL-encoded params). Instead: (a) PREFER asserting visible page CONTENT over toHaveURL(). (b) If you must check the URL, use the LOOSEST possible regex that only checks the hostname — e.g. await expect(page).toHaveURL(/example\\.com/i) — never match on path segments or query params. (c) For search flows, assert that results appeared on the page rather than checking the URL. (d) NEVER use toHaveURL() with a literal string — it will fail on any redirect, query param, or geo-variant of the URL. (e) NEVER add toHaveURL() as a final assertion after a search, filter, or form action — the URL will contain query params that make an exact match impossible.
-- After every page.goto() use { waitUntil: 'domcontentloaded' } — NEVER use waitForLoadState('networkidle') as SPAs and e-commerce sites continuously fire background requests and never reach networkidle, causing a guaranteed 30s timeout. After clicking a button or link that causes navigation, use await Promise.all([page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 30000 }), element.click()]). For asserting dynamic content, use await page.waitForSelector('selector', { timeout: 15000 }) before the expect() assertion.`.trim();
+- After every page.goto() use { waitUntil: 'domcontentloaded' } — NEVER use waitForLoadState('networkidle') as SPAs and e-commerce sites continuously fire background requests and never reach networkidle, causing a guaranteed 30s timeout. After clicking a button or link that causes navigation, use await Promise.all([page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 30000 }), element.click()]). For asserting dynamic content, use await page.waitForSelector('selector', { timeout: 15000 }) before the expect() assertion.
+- ASYNC CONTENT & LOADING STATES: SPAs and dynamic pages often show loading spinners, skeleton screens, or "Loading..." text before real content appears. NEVER assert on content that may still be loading. Before asserting on async content: (a) Wait for the real content to appear: await page.waitForSelector('[data-loaded], .content:not(.loading)', { timeout: 15000 }).catch(() => {}); (b) Or wait for a loading indicator to disappear: await page.locator('.spinner, .loading, [aria-busy="true"]').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {}); (c) Use Playwright's built-in auto-waiting by asserting with a timeout: await expect(page.locator('...')).toContainText('expected', { timeout: 10000 });`.trim();
 
 // ─── JSON output schema block ────────────────────────────────────────────────
 // Shared by all three prompt builders. The example values guide the LLM on
@@ -103,7 +112,7 @@ ${isLocalProvider() ? "" : buildFewShotBlock()}`.trim();
 // produced which tests, A/B test prompt changes, and roll back if quality
 // regresses.
 
-export const PROMPT_VERSION = "2.1.0";
+export const PROMPT_VERSION = "2.2.0";
 
 export function buildSystemPrompt() {
   return `You are a senior QA automation engineer generating production-grade Playwright test suites.

--- a/backend/src/routes/testFix.js
+++ b/backend/src/routes/testFix.js
@@ -67,6 +67,13 @@ function buildUserPrompt(test, failureResult, project) {
       failureResult.steps.forEach((s, i) => lines.push(`  ${i + 1}. ${s}`));
       lines.push("");
     }
+
+    const dom = failureResult.domSnapshot;
+    if (dom && typeof dom === "string") {
+      lines.push("DOM snapshot excerpt (trimmed):");
+      lines.push(dom.slice(0, 2500));
+      lines.push("");
+    }
   }
 
   if (test.steps?.length) {

--- a/backend/src/routes/testFix.js
+++ b/backend/src/routes/testFix.js
@@ -69,9 +69,13 @@ function buildUserPrompt(test, failureResult, project) {
     }
 
     const dom = failureResult.domSnapshot;
-    if (dom && typeof dom === "string") {
+    if (dom) {
       lines.push("DOM snapshot excerpt (trimmed):");
-      lines.push(dom.slice(0, 2500));
+      lines.push(
+        typeof dom === "string"
+          ? dom.slice(0, 2500)
+          : JSON.stringify(dom, null, 2).slice(0, 2500)
+      );
       lines.push("");
     }
   }

--- a/backend/src/runner/executeTest.js
+++ b/backend/src/runner/executeTest.js
@@ -193,9 +193,18 @@ export async function executeTest(test, browser, runId, stepIndex, runStart) {
     viewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
     permissions: ["geolocation", "notifications"],
     ignoreHTTPSErrors: true,
+    // Enable downloads so page.waitForEvent('download') works (#42)
+    acceptDownloads: true,
   });
 
   const page = await context.newPage();
+
+  // Auto-accept dialogs (window.alert, confirm, prompt) so they don't hang
+  // the test until timeout. Tests that need to dismiss can override with
+  // page.on('dialog', d => d.dismiss()) before the triggering action. (#40)
+  page.on("dialog", (dialog) => {
+    dialog.accept().catch(() => {});
+  });
 
   // Start CDP screencast (returns cleanup fn or null)
   const stopScreencast = await startScreencast(page, runId);
@@ -329,6 +338,13 @@ export async function executeTest(test, browser, runId, stepIndex, runStart) {
     // handlers from calling res.url()/res.status() on a closed page,
     // which would throw an unhandled rejection and crash Node.js.
     disposeListeners();
+
+    // Close any popup / new-tab pages opened during the test so they don't
+    // leak browser memory. context.pages() includes the main page — skip it
+    // and close everything else. (#41)
+    for (const p of context.pages()) {
+      if (p !== page) await p.close().catch(() => {});
+    }
 
     // Close page first then context — this flushes video to disk
     await page.close().catch(() => {});

--- a/backend/src/runner/executeTest.js
+++ b/backend/src/runner/executeTest.js
@@ -256,9 +256,10 @@ export async function executeTest(test, browser, runId, stepIndex, runStart) {
           await page.waitForTimeout(800);
         }
 
-        const healingHints = getHealingHistoryForTest(test.id);
+        const healingScopeId = `${test.id}@v${test.codeVersion || 0}`;
+        const healingHints = getHealingHistoryForTest(healingScopeId);
         const codeResult = await runGeneratedCode(page, context, test.playwrightCode, expect, healingHints);
-        persistHealingEvents(test.id, codeResult.healingEvents);
+        persistHealingEvents(healingScopeId, codeResult.healingEvents);
 
       } else {
         // ── FALLBACK: No parseable code — run a basic smoke test ───────────
@@ -299,7 +300,8 @@ export async function executeTest(test, browser, runId, stepIndex, runStart) {
     result.error = formatTestError(err);
 
     // Persist healing events from the failed run
-    persistHealingEvents(test.id, err.__healingEvents);
+    const healingScopeId = `${test.id}@v${test.codeVersion || 0}`;
+    persistHealingEvents(healingScopeId, err.__healingEvents);
 
     // Screenshot the failure state
     try {

--- a/backend/src/selfHealing.js
+++ b/backend/src/selfHealing.js
@@ -120,7 +120,7 @@ const HEALING_VISIBLE_WAIT_CAP = parseInt(process.env.HEALING_VISIBLE_WAIT_CAP, 
 // (e.g. adding/removing/reordering strategies in safeClick, safeFill, etc.).
 // Healing hints recorded with a different version are ignored so stale
 // strategyIndex values don't point to the wrong strategy after an upgrade.
-const STRATEGY_VERSION = 2;
+const STRATEGY_VERSION = 3;
 
 /**
  * Generate the self-healing runtime helper code as a string for injection
@@ -513,7 +513,161 @@ export function getSelfHealingHelperCode(healingHints) {
       });
     }
 
-    // safeExpect — self-healing visibility assertions
+    // ── safeDrag — drag and drop with self-healing source/target lookup ──────
+    async function safeDrag(page, sourceText, targetText) {
+      if (sourceText == null || typeof sourceText !== 'string' || !sourceText.trim()) {
+        throw new Error('safeDrag: sourceText argument is required (got ' + typeof sourceText + ')');
+      }
+      if (targetText == null || typeof targetText !== 'string' || !targetText.trim()) {
+        throw new Error('safeDrag: targetText argument is required (got ' + typeof targetText + ')');
+      }
+      const makeStrategies = (text) => looksLikeSelector(text)
+        ? [p => p.locator(text)]
+        : [
+          p => p.getByText(text, { exact: true }),
+          p => p.getByText(text),
+          p => p.getByRole('listitem', { name: text }),
+          p => p.getByRole('treeitem', { name: text }),
+          p => p.locator(\`[aria-label*="\${text}"]\`),
+          p => p.locator(\`[title*="\${text}"]\`),
+        ];
+
+      await retry(async () => {
+        const src = await findElement(page, makeStrategies(sourceText), { healingKey: 'drag-src::' + sourceText });
+        const tgt = await findElement(page, makeStrategies(targetText), { healingKey: 'drag-tgt::' + targetText });
+        await ensureReady(src);
+        await src.dragTo(tgt);
+      });
+    }
+
+    // ── safeUpload — file upload with self-healing element lookup ────────────
+    async function safeUpload(page, labelOrSelector, files) {
+      if (labelOrSelector == null || typeof labelOrSelector !== 'string' || !labelOrSelector.trim()) {
+        throw new Error('safeUpload: labelOrSelector argument is required (got ' + typeof labelOrSelector + ')');
+      }
+      const strategies = looksLikeSelector(labelOrSelector)
+        ? [p => p.locator(labelOrSelector)]
+        : [
+          p => p.getByLabel(labelOrSelector),
+          p => p.getByRole('button', { name: labelOrSelector }),
+          p => p.getByText(labelOrSelector, { exact: true }),
+          p => p.locator(\`input[type="file"][aria-label*="\${labelOrSelector}"]\`),
+          p => p.locator('input[type="file"]'),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'upload::' + labelOrSelector });
+        await el.setInputFiles(files);
+      });
+    }
+
+    // ── safeFocus — focus with self-healing element lookup ───────────────────
+    async function safeFocus(page, labelOrText) {
+      if (labelOrText == null || typeof labelOrText !== 'string' || !labelOrText.trim()) {
+        throw new Error('safeFocus: labelOrText argument is required (got ' + typeof labelOrText + ')');
+      }
+      const strategies = looksLikeSelector(labelOrText)
+        ? [p => p.locator(labelOrText)]
+        : [
+          p => onlyFillable(p.getByLabel(labelOrText)),
+          p => p.getByPlaceholder(labelOrText),
+          p => p.getByRole('textbox', { name: labelOrText }),
+          p => p.getByRole('button', { name: labelOrText }),
+          p => p.getByText(labelOrText, { exact: true }),
+          p => p.locator(\`[aria-label*="\${labelOrText}"]\`),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'focus::' + labelOrText });
+        await ensureReady(el);
+        await el.focus();
+      });
+    }
+
+    // ── safeTap — touch tap with self-healing (mobile viewports) ────────────
+    async function safeTap(page, text) {
+      if (text == null || typeof text !== 'string' || !text.trim()) {
+        throw new Error('safeTap: text argument is required (got ' + typeof text + ')');
+      }
+      const strategies = looksLikeSelector(text)
+        ? [p => p.locator(text)]
+        : [
+          p => p.getByRole('button', { name: text }),
+          p => p.getByRole('link',   { name: text }),
+          p => p.getByText(text, { exact: true }),
+          p => p.getByText(text),
+          p => p.locator(\`[aria-label*="\${text}"]\`),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'tap::' + text });
+        await ensureReady(el);
+        await el.tap();
+      });
+    }
+
+    // ── safePress — keyboard press on a specific element ────────────────────
+    async function safePress(page, labelOrSelector, key) {
+      if (labelOrSelector == null || typeof labelOrSelector !== 'string' || !labelOrSelector.trim()) {
+        throw new Error('safePress: labelOrSelector argument is required (got ' + typeof labelOrSelector + ')');
+      }
+      const strategies = looksLikeSelector(labelOrSelector)
+        ? [p => p.locator(labelOrSelector)]
+        : [
+          p => onlyFillable(p.getByLabel(labelOrSelector)),
+          p => p.getByPlaceholder(labelOrSelector),
+          p => p.getByRole('textbox', { name: labelOrSelector }),
+          p => p.getByRole('button', { name: labelOrSelector }),
+          p => p.getByText(labelOrSelector, { exact: true }),
+          p => p.locator(\`[aria-label*="\${labelOrSelector}"]\`),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'press::' + labelOrSelector });
+        await ensureReady(el);
+        await el.press(key);
+      });
+    }
+
+    // ── safeRightClick — context-menu click with self-healing ────────────────
+    async function safeRightClick(page, text) {
+      if (text == null || typeof text !== 'string' || !text.trim()) {
+        throw new Error('safeRightClick: text argument is required (got ' + typeof text + ')');
+      }
+      const strategies = looksLikeSelector(text)
+        ? [p => p.locator(text)]
+        : [
+          p => p.getByRole('button', { name: text }),
+          p => p.getByRole('link',   { name: text }),
+          p => p.getByRole('treeitem', { name: text }),
+          p => p.getByRole('listitem', { name: text }),
+          p => p.getByText(text, { exact: true }),
+          p => p.getByText(text),
+          p => p.locator(\`[aria-label*="\${text}"]\`),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'rightclick::' + text });
+        await ensureReady(el);
+        await el.click({ button: 'right', timeout: DEFAULT_TIMEOUT });
+      });
+    }
+
+    // ── safeSelectFrame — switch into an iframe with self-healing ────────────
+    function safeSelectFrame(page, selectorOrName) {
+      if (selectorOrName == null || typeof selectorOrName !== 'string' || !selectorOrName.trim()) {
+        throw new Error('safeSelectFrame: selectorOrName argument is required');
+      }
+      // Returns a FrameLocator — callers chain further locator calls on it.
+      // Try the raw selector first, then fall back to name/title attributes.
+      if (looksLikeSelector(selectorOrName)) {
+        return page.frameLocator(selectorOrName);
+      }
+      // Attempt by title, name, or aria-label
+      return page.frameLocator(\`iframe[title*="\${selectorOrName}"], iframe[name*="\${selectorOrName}"], iframe[aria-label*="\${selectorOrName}"]\`);
+    }
+
+    // ── safeExpect — self-healing visibility assertions
     //
     // Covers ALL common ARIA roles so the AI's role guess doesn't break the test.
     async function safeExpect(page, expect, text, role) {
@@ -778,6 +932,96 @@ export function applyHealingTransforms(code) {
       /page\.locator\(['"`]([^'"`]+)['"`]\)\.selectOption\(([^)]+)\)/g,
       (match, sel, val) => looksLikeCssSelector(sel) ? match : `safeSelect(page, '${esc(sel)}', ${val})`
     )
+    // ── Type transforms → safeFill (page.type is deprecated but AI emits it) ─
+    .replace(
+      /\bpage\.type\(['"`]([^'"`]+)['"`],\s*([^)]+)\)/g,
+      (match, arg, val) => looksLikeCssSelector(arg) ? match : `safeFill(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.locator\(['"`]([^'"`]+)['"`]\)\.type\(([^)]+)\)/g,
+      (match, sel, val) => looksLikeCssSelector(sel) ? match : `safeFill(page, '${esc(sel)}', ${val})`
+    )
+    .replace(
+      /page\.getByLabel\(['"`]([^'"`]+)['"`]\)\.type\(([^)]+)\)/g,
+      (match, arg, val) => `safeFill(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.getByPlaceholder\(['"`]([^'"`]+)['"`]\)\.type\(([^)]+)\)/g,
+      (match, arg, val) => `safeFill(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.getByTestId\(['"`]([^'"`]+)['"`]\)\.type\(([^)]+)\)/g,
+      (match, arg, val) => `safeFill(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.getByRole\(['"`][^'"`]+['"`],\s*\{\s*name:\s*['"`]([^'"`]+)['"`]\s*\}\)\.type\(([^)]+)\)/g,
+      (match, arg, val) => `safeFill(page, '${esc(arg)}', ${val})`
+    )
+    // ── Missing check/uncheck/selectOption locator variants ──────────────────
+    .replace(
+      /page\.getByRole\(['"`][^'"`]+['"`],\s*\{\s*name:\s*['"`]([^'"`]+)['"`]\s*\}\)\.check\(\)/g,
+      (match, arg) => `safeCheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByRole\(['"`][^'"`]+['"`],\s*\{\s*name:\s*['"`]([^'"`]+)['"`]\s*\}\)\.uncheck\(\)/g,
+      (match, arg) => `safeUncheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByRole\(['"`][^'"`]+['"`],\s*\{\s*name:\s*['"`]([^'"`]+)['"`]\s*\}\)\.selectOption\(([^)]+)\)/g,
+      (match, arg, val) => `safeSelect(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.getByTestId\(['"`]([^'"`]+)['"`]\)\.check\(\)/g,
+      (match, arg) => `safeCheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByTestId\(['"`]([^'"`]+)['"`]\)\.uncheck\(\)/g,
+      (match, arg) => `safeUncheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByTestId\(['"`]([^'"`]+)['"`]\)\.selectOption\(([^)]+)\)/g,
+      (match, arg, val) => `safeSelect(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.getByPlaceholder\(['"`]([^'"`]+)['"`]\)\.check\(\)/g,
+      (match, arg) => `safeCheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByPlaceholder\(['"`]([^'"`]+)['"`]\)\.uncheck\(\)/g,
+      (match, arg) => `safeUncheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByPlaceholder\(['"`]([^'"`]+)['"`]\)\.selectOption\(([^)]+)\)/g,
+      (match, arg, val) => `safeSelect(page, '${esc(arg)}', ${val})`
+    )
+    // ── Tap transforms → safeTap ────────────────────────────────────────────
+    .replace(
+      /\bpage\.tap\(['"`]([^'"`]+)['"`]\)/g,
+      (match, arg) => looksLikeCssSelector(arg) ? match : `safeTap(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.locator\(['"`]([^'"`]+)['"`]\)\.tap\(\)/g,
+      (match, sel) => looksLikeCssSelector(sel) ? match : `safeTap(page, '${esc(sel)}')`
+    )
+    // ── Focus transforms → safeFocus ────────────────────────────────────────
+    .replace(
+      /\bpage\.focus\(['"`]([^'"`]+)['"`]\)/g,
+      (match, arg) => looksLikeCssSelector(arg) ? match : `safeFocus(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.locator\(['"`]([^'"`]+)['"`]\)\.focus\(\)/g,
+      (match, sel) => looksLikeCssSelector(sel) ? match : `safeFocus(page, '${esc(sel)}')`
+    )
+    // ── DragTo transforms → safeDrag ────────────────────────────────────────
+    .replace(
+      /\bpage\.dragAndDrop\(['"`]([^'"`]+)['"`],\s*['"`]([^'"`]+)['"`]\)/g,
+      (match, src, tgt) => `safeDrag(page, '${esc(src)}', '${esc(tgt)}')`
+    )
+    // ── Press transforms → safePress ────────────────────────────────────────
+    .replace(
+      /\bpage\.press\(['"`]([^'"`]+)['"`],\s*['"`]([^'"`]+)['"`]\)/g,
+      (match, sel, key) => looksLikeCssSelector(sel) ? match : `safePress(page, '${esc(sel)}', '${esc(key)}')`
+    )
     // ── Assertion transforms ────────────────────────────────────────────────
     // Rewrite ALL role-based visibility assertions into safeExpect.
     // Covers every common ARIA role — not just the original 5.
@@ -850,19 +1094,62 @@ INTERACTIONS — use these exclusively:
   ✓ await safeClick(page, text)            — for any click
   ✓ await safeDblClick(page, text)         — for any double-click
   ✓ await safeHover(page, text)            — for any hover (menus, tooltips)
-  ✓ await safeFill(page, label, value)     — for any input fill
+  ✓ await safeFill(page, label, value)     — for any input fill (also replaces page.type)
   ✓ await safeSelect(page, label, value)   — for any select/dropdown
   ✓ await safeCheck(page, label)           — for checkbox/radio checked state
   ✓ await safeUncheck(page, label)         — for checkbox/radio unchecked state
+  ✓ await safeDrag(page, sourceText, targetText) — for drag-and-drop
+  ✓ await safeUpload(page, label, filePaths)     — for file upload (accepts string or string[])
+  ✓ await safeFocus(page, label)           — for focusing an element
+  ✓ await safeTap(page, text)              — for touch tap (mobile viewports)
+  ✓ await safePress(page, label, key)      — for pressing a key on a focused element
+  ✓ await safeRightClick(page, text)       — for context-menu / right-click
+
+IFRAME / FRAME — use safeSelectFrame to get a FrameLocator, then chain helpers:
+  ✓ const frame = safeSelectFrame(page, 'Payment')  — returns a FrameLocator
+    Then use frame.locator(...) or frame.getByRole(...) inside the iframe.
+
+DIALOGS (window.alert / confirm / prompt):
+  Dialogs are auto-accepted by the runtime. If you need to dismiss instead:
+  ✓ page.on('dialog', d => d.dismiss())    — register BEFORE the action that triggers it
+
+NEW TABS / POPUPS:
+  ✓ const [newPage] = await Promise.all([
+      context.waitForEvent('page'),
+      safeClick(page, 'Open in new tab'),
+    ]);
+    await newPage.waitForLoadState('domcontentloaded');
+    // ... interact with newPage ...
+    await newPage.close();
+
+DOWNLOADS:
+  ✓ const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      safeClick(page, 'Download PDF'),
+    ]);
+    const path = await download.path();
+
+KEYBOARD (global, not element-scoped):
+  ✓ await page.keyboard.press('Enter')     — for global key presses (Escape, Tab, etc.)
+  ✓ await page.keyboard.type('search term') — for typing without a specific element
+
+MOUSE (coordinate-based — use only when no element label exists):
+  ✓ await page.mouse.click(x, y)
+  ✓ await page.mouse.move(x, y)
+  ✓ await page.mouse.wheel(0, 500)         — for scrolling
 
 VISIBILITY ASSERTIONS — use safeExpect instead of raw locators:
   ✓ await safeExpect(page, expect, text)           — assert any element is visible
   ✓ await safeExpect(page, expect, text, 'button') — scoped to a role
 
-COUNT / VALUE ASSERTIONS — use page.locator() scoped to a semantic selector:
+COUNT / VALUE / STATE ASSERTIONS — use page.locator() scoped to a semantic selector:
   ✓ await expect(page.locator(...)).toHaveCount(5);
   ✓ await expect(page.locator(...)).toHaveValue('expected');
   ✓ await expect(page.locator(...)).not.toHaveCount(0);
+  ✓ await expect(page.locator(...)).toBeHidden();
+  ✓ await expect(page.locator(...)).toHaveAttribute('href', /expected/);
+  ✓ await expect(page.locator(...)).toHaveClass(/active/);
+  ✓ await expect(page.locator(...)).toHaveCSS('color', 'rgb(0, 0, 0)');
     BAD:  const items = page.locator(...); await expect(items).toHaveCount(5);
     GOOD: await expect(page.locator(...)).toHaveCount(5);
   ✗ NEVER assert a hard-coded count on a generic container that may change (e.g. toHaveCount(5) on search results).
@@ -874,6 +1161,8 @@ OTHER ASSERTIONS — these are fine as-is (do not wrap them):
   ✓ await expect(locator).toContainText(...)
   ✓ await expect(locator).toHaveValue(...)
   ✓ await expect(locator).toBeEnabled()
+  ✓ await expect(locator).toBeDisabled()
+  ✓ await expect(locator).toBeChecked()
 
 FORBIDDEN — never use these (they bypass self-healing and will break on selector changes):
 
@@ -886,7 +1175,10 @@ FORBIDDEN — never use these (they bypass self-healing and will break on select
   ✗ page.getByPlaceholder(...).click()
   ✗ page.getByTestId(...).click()
   ✗ page.getByAltText(...).click()
+
+  Taps (use safeTap instead):
   ✗ page.tap(...)
+  ✗ page.locator(...).tap()
 
   Fills / typing (use safeFill instead):
   ✗ page.fill(...)
@@ -894,8 +1186,13 @@ FORBIDDEN — never use these (they bypass self-healing and will break on select
   ✗ page.locator(...).fill(...)
   ✗ page.locator(...).type(...)
   ✗ page.getByLabel(...).fill(...)
-  ✗ page.getByPlaceholder(...).fill(...)   ← already handled by safeFill
+  ✗ page.getByLabel(...).type(...)
+  ✗ page.getByPlaceholder(...).fill(...)
+  ✗ page.getByPlaceholder(...).type(...)
   ✗ page.getByTestId(...).fill(...)
+  ✗ page.getByTestId(...).type(...)
+  ✗ page.getByRole(...).fill(...)
+  ✗ page.getByRole(...).type(...)
 
   Form controls (use safeSelect/safeCheck/safeUncheck):
   ✗ page.check(...)
@@ -904,6 +1201,16 @@ FORBIDDEN — never use these (they bypass self-healing and will break on select
   ✗ page.locator(...).check()
   ✗ page.locator(...).uncheck()
   ✗ page.locator(...).selectOption(...)
+  ✗ page.getByRole(...).check()
+  ✗ page.getByRole(...).uncheck()
+  ✗ page.getByRole(...).selectOption(...)
+  ✗ page.getByLabel(...).selectOption(...)
+  ✗ page.getByTestId(...).check()
+  ✗ page.getByTestId(...).uncheck()
+  ✗ page.getByTestId(...).selectOption(...)
+  ✗ page.getByPlaceholder(...).check()
+  ✗ page.getByPlaceholder(...).uncheck()
+  ✗ page.getByPlaceholder(...).selectOption(...)
 
   Double-clicks (use safeDblClick instead):
   ✗ page.dblclick(...)
@@ -919,11 +1226,20 @@ FORBIDDEN — never use these (they bypass self-healing and will break on select
   ✗ page.getByRole(...).hover()
   ✗ page.getByTestId(...).hover()
 
-  Other interactions (no self-healing equivalent — avoid if possible):
-  ✗ page.press(...)                        ← use page.keyboard.press() only when absolutely needed
-  ✗ page.focus(...)
-  ✗ page.dragTo(...)
+  Drag-and-drop (use safeDrag instead):
+  ✗ page.dragAndDrop(...)
+  ✗ locator.dragTo(...)
+
+  File upload (use safeUpload instead):
   ✗ page.setInputFiles(...)
+  ✗ locator.setInputFiles(...)
+
+  Focus (use safeFocus instead):
+  ✗ page.focus(...)
+  ✗ locator.focus()
+
+  Press on selector (use safePress instead):
+  ✗ page.press(selector, key)              ← use safePress(page, label, key)
 
   Visibility assertions (use safeExpect instead):
   ✗ expect(page.getByRole(...)).toBeVisible()
@@ -936,6 +1252,6 @@ FORBIDDEN — never use these (they bypass self-healing and will break on select
 
   Variable-based locator declarations (always inline inside expect()):
   ✗ const searchInput = page.locator(...);   ← declare AND use in one line, or use safeFill/safeClick
-  ✗ const results = page.locator(...);  ← inline: expect(page.locator(...)).toHaveCount(N)
-  ✗ const searchButton = page.locator(...);     ← use safeClick(page, text) instead
+  ✗ const results = page.locator(...);       ← inline: expect(page.locator(...)).toHaveCount(N)
+  ✗ const searchButton = page.locator(...);  ← use safeClick(page, text) instead
 `.trim();

--- a/backend/src/selfHealing.js
+++ b/backend/src/selfHealing.js
@@ -46,6 +46,7 @@ export function recordHealing(testId, action, label, strategyIndex) {
   const existing = healingRepo.get(key);
   healingRepo.set(key, {
     strategyIndex: idx,
+    strategyVersion: STRATEGY_VERSION,
     succeededAt: new Date().toISOString(),
     failCount: existing?.failCount || 0,
   });
@@ -79,6 +80,9 @@ export function getHealingHint(testId, action, label) {
   const key = `${testId}::${action}::${label}`;
   const entry = healingRepo.get(key);
   if ((entry?.failCount || 0) >= HEALING_HINT_MAX_FAILS) return -1;
+  // Ignore hints from a different strategy version — the strategyIndex
+  // may point to a different strategy after strategies were reordered.
+  if (entry?.strategyVersion != null && entry.strategyVersion !== STRATEGY_VERSION) return -1;
   return entry?.strategyIndex ?? -1;
 }
 
@@ -95,6 +99,8 @@ export function getHealingHistoryForTest(testId) {
     const idx = val.strategyIndex;
     if ((val?.failCount || 0) >= HEALING_HINT_MAX_FAILS) continue;
     if (!Number.isInteger(idx) || idx < 0) continue;
+    // Skip hints from a different strategy version
+    if (val.strategyVersion != null && val.strategyVersion !== STRATEGY_VERSION) continue;
     result[shortKey] = idx;
   }
   return result;
@@ -109,6 +115,12 @@ const HEALING_RETRY_COUNT     = parseInt(process.env.HEALING_RETRY_COUNT, 10) ||
 const HEALING_RETRY_DELAY     = parseInt(process.env.HEALING_RETRY_DELAY, 10) || 400;
 const HEALING_HINT_MAX_FAILS  = parseInt(process.env.HEALING_HINT_MAX_FAILS, 10) || 3;
 const HEALING_VISIBLE_WAIT_CAP = parseInt(process.env.HEALING_VISIBLE_WAIT_CAP, 10) || 1200;
+
+// Strategy version — bump this whenever the strategy waterfall order changes
+// (e.g. adding/removing/reordering strategies in safeClick, safeFill, etc.).
+// Healing hints recorded with a different version are ignored so stale
+// strategyIndex values don't point to the wrong strategy after an upgrade.
+const STRATEGY_VERSION = 2;
 
 /**
  * Generate the self-healing runtime helper code as a string for injection
@@ -176,7 +188,14 @@ export function getSelfHealingHelperCode(healingHints) {
       if (!baseLocator) {
         throw new Error('Strategy returned a null/undefined locator');
       }
+      // Fast path: check if any element is already visible without waiting.
+      // This avoids the expensive waitFor timeout for strategies that clearly
+      // don't match, reducing worst-case waterfall time significantly.
       const count = await baseLocator.count().catch(() => 0);
+      if (count === 0) {
+        // No elements at all — fail fast instead of waiting the full timeout.
+        throw new Error('No elements matched this strategy');
+      }
       for (let n = 0; n < count; n++) {
         const candidate = baseLocator.nth(n);
         const visible = await candidate.isVisible().catch(() => false);

--- a/backend/src/selfHealing.js
+++ b/backend/src/selfHealing.js
@@ -78,6 +78,7 @@ export function getHealingHint(testId, action, label) {
   if (!testId || !action || typeof label !== "string") return -1;
   const key = `${testId}::${action}::${label}`;
   const entry = healingRepo.get(key);
+  if ((entry?.failCount || 0) >= HEALING_HINT_MAX_FAILS) return -1;
   return entry?.strategyIndex ?? -1;
 }
 
@@ -92,6 +93,7 @@ export function getHealingHistoryForTest(testId) {
   const result = {};
   for (const [shortKey, val] of Object.entries(entries)) {
     const idx = val.strategyIndex;
+    if ((val?.failCount || 0) >= HEALING_HINT_MAX_FAILS) continue;
     if (!Number.isInteger(idx) || idx < 0) continue;
     result[shortKey] = idx;
   }
@@ -105,6 +107,8 @@ export function getHealingHistoryForTest(testId) {
 const HEALING_ELEMENT_TIMEOUT = parseInt(process.env.HEALING_ELEMENT_TIMEOUT, 10) || 5000;
 const HEALING_RETRY_COUNT     = parseInt(process.env.HEALING_RETRY_COUNT, 10) || 3;
 const HEALING_RETRY_DELAY     = parseInt(process.env.HEALING_RETRY_DELAY, 10) || 400;
+const HEALING_HINT_MAX_FAILS  = parseInt(process.env.HEALING_HINT_MAX_FAILS, 10) || 3;
+const HEALING_VISIBLE_WAIT_CAP = parseInt(process.env.HEALING_VISIBLE_WAIT_CAP, 10) || 1200;
 
 /**
  * Generate the self-healing runtime helper code as a string for injection
@@ -126,6 +130,7 @@ export function getSelfHealingHelperCode(healingHints) {
     const DEFAULT_TIMEOUT = ${HEALING_ELEMENT_TIMEOUT};
     const RETRY_COUNT = ${HEALING_RETRY_COUNT};
     const RETRY_DELAY = ${HEALING_RETRY_DELAY};
+    const FIRST_VISIBLE_WAIT_CAP = ${HEALING_VISIBLE_WAIT_CAP};
 
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
     const looksLikeSelector = (value) => {
@@ -180,7 +185,8 @@ export function getSelfHealingHelperCode(healingHints) {
       // No element is visible yet — wait for the first one to appear.
       // This preserves the original timeout-based retry behaviour.
       const first = baseLocator.first();
-      await first.waitFor({ state: 'visible', timeout });
+      const waitTimeout = Math.min(timeout, FIRST_VISIBLE_WAIT_CAP);
+      await first.waitFor({ state: 'visible', timeout: waitTimeout });
       return first;
     }
 
@@ -413,6 +419,65 @@ export function getSelfHealingHelperCode(healingHints) {
       });
     }
 
+    async function safeSelect(page, labelOrText, value) {
+      if (labelOrText == null || typeof labelOrText !== 'string' || !labelOrText.trim()) {
+        throw new Error('safeSelect: labelOrText argument is required (got ' + typeof labelOrText + ')');
+      }
+      const strValue = (value == null) ? '' : String(value);
+      const strategies = looksLikeSelector(labelOrText)
+        ? [p => p.locator(labelOrText)]
+        : [
+          p => p.getByLabel(labelOrText),
+          p => p.getByRole('combobox', { name: labelOrText }),
+          p => p.getByRole('listbox', { name: labelOrText }),
+          p => p.locator(\`select[aria-label*="\${labelOrText}"]\`),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'select::' + labelOrText });
+        await ensureReady(el);
+        await el.selectOption(strValue);
+      });
+    }
+
+    async function safeCheck(page, labelOrText) {
+      if (labelOrText == null || typeof labelOrText !== 'string' || !labelOrText.trim()) {
+        throw new Error('safeCheck: labelOrText argument is required (got ' + typeof labelOrText + ')');
+      }
+      const strategies = looksLikeSelector(labelOrText)
+        ? [p => p.locator(labelOrText)]
+        : [
+          p => p.getByRole('checkbox', { name: labelOrText }),
+          p => p.getByLabel(labelOrText),
+          p => p.locator(\`[aria-label*="\${labelOrText}"]\`),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'check::' + labelOrText });
+        await ensureReady(el);
+        await el.check();
+      });
+    }
+
+    async function safeUncheck(page, labelOrText) {
+      if (labelOrText == null || typeof labelOrText !== 'string' || !labelOrText.trim()) {
+        throw new Error('safeUncheck: labelOrText argument is required (got ' + typeof labelOrText + ')');
+      }
+      const strategies = looksLikeSelector(labelOrText)
+        ? [p => p.locator(labelOrText)]
+        : [
+          p => p.getByRole('checkbox', { name: labelOrText }),
+          p => p.getByLabel(labelOrText),
+          p => p.locator(\`[aria-label*="\${labelOrText}"]\`),
+        ];
+
+      await retry(async () => {
+        const el = await findElement(page, strategies, { healingKey: 'uncheck::' + labelOrText });
+        await ensureReady(el);
+        await el.uncheck();
+      });
+    }
+
     // safeExpect — self-healing visibility assertions
     //
     // Covers ALL common ARIA roles so the AI's role guess doesn't break the test.
@@ -642,6 +707,34 @@ export function applyHealingTransforms(code) {
       /page\.locator\(['"`]([^'"`]+)['"`]\)\.fill\(([^)]+)\)/g,
       (match, sel, val) => looksLikeCssSelector(sel) ? match : `safeFill(page, '${esc(sel)}', ${val})`
     )
+    .replace(
+      /\bpage\.check\(['"`]([^'"`]+)['"`]\)/g,
+      (match, arg) => looksLikeCssSelector(arg) ? match : `safeCheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /\bpage\.uncheck\(['"`]([^'"`]+)['"`]\)/g,
+      (match, arg) => looksLikeCssSelector(arg) ? match : `safeUncheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByLabel\(['"`]([^'"`]+)['"`]\)\.check\(\)/g,
+      (match, arg) => `safeCheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.getByLabel\(['"`]([^'"`]+)['"`]\)\.uncheck\(\)/g,
+      (match, arg) => `safeUncheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /\bpage\.selectOption\(['"`]([^'"`]+)['"`],\s*([^)]+)\)/g,
+      (match, arg, val) => looksLikeCssSelector(arg) ? match : `safeSelect(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.getByLabel\(['"`]([^'"`]+)['"`]\)\.selectOption\(([^)]+)\)/g,
+      (match, arg, val) => `safeSelect(page, '${esc(arg)}', ${val})`
+    )
+    .replace(
+      /page\.locator\(['"`]([^'"`]+)['"`]\)\.selectOption\(([^)]+)\)/g,
+      (match, sel, val) => looksLikeCssSelector(sel) ? match : `safeSelect(page, '${esc(sel)}', ${val})`
+    )
     // ── Assertion transforms ────────────────────────────────────────────────
     // Rewrite ALL role-based visibility assertions into safeExpect.
     // Covers every common ARIA role — not just the original 5.
@@ -715,6 +808,9 @@ INTERACTIONS — use these exclusively:
   ✓ await safeDblClick(page, text)         — for any double-click
   ✓ await safeHover(page, text)            — for any hover (menus, tooltips)
   ✓ await safeFill(page, label, value)     — for any input fill
+  ✓ await safeSelect(page, label, value)   — for any select/dropdown
+  ✓ await safeCheck(page, label)           — for checkbox/radio checked state
+  ✓ await safeUncheck(page, label)         — for checkbox/radio unchecked state
 
 VISIBILITY ASSERTIONS — use safeExpect instead of raw locators:
   ✓ await safeExpect(page, expect, text)           — assert any element is visible
@@ -758,7 +854,7 @@ FORBIDDEN — never use these (they bypass self-healing and will break on select
   ✗ page.getByPlaceholder(...).fill(...)   ← already handled by safeFill
   ✗ page.getByTestId(...).fill(...)
 
-  Form controls (use safeFill or safeClick instead):
+  Form controls (use safeSelect/safeCheck/safeUncheck):
   ✗ page.check(...)
   ✗ page.uncheck(...)
   ✗ page.selectOption(...)

--- a/backend/src/selfHealing.js
+++ b/backend/src/selfHealing.js
@@ -259,12 +259,17 @@ export function getSelfHealingHelperCode(healingHints) {
     }
 
     async function ensureReady(locator) {
-      // All three steps are best-effort: if the element is momentarily detached
+      // All steps are best-effort: if the element is momentarily detached
       // or hidden, we still want to attempt scroll + attach before giving up.
       // The caller's retry loop will re-attempt the full sequence if needed.
       try { await locator.waitFor({ state: 'visible', timeout: DEFAULT_TIMEOUT }); } catch {}
       try { await locator.scrollIntoViewIfNeeded(); } catch {}
       try { await locator.waitFor({ state: 'attached' }); } catch {}
+      // Brief DOM stability pause — gives SPAs time to finish re-rendering
+      // after the element appears. Without this, actions can fire while the
+      // DOM is still mutating (e.g. text changing from "Loading..." to real
+      // content), causing stale-element or wrong-value assertions.
+      try { await locator.page().waitForTimeout(100); } catch {}
     }
 
     async function safeClick(page, text) {

--- a/backend/src/selfHealing.js
+++ b/backend/src/selfHealing.js
@@ -423,7 +423,18 @@ export function getSelfHealingHelperCode(healingHints) {
       if (labelOrText == null || typeof labelOrText !== 'string' || !labelOrText.trim()) {
         throw new Error('safeSelect: labelOrText argument is required (got ' + typeof labelOrText + ')');
       }
-      const strValue = (value == null) ? '' : String(value);
+      // Playwright's selectOption() accepts string, { label?, value?, index? },
+      // or arrays for multi-select. Only coerce primitives (number/boolean) to
+      // string — preserve objects and arrays so callers can use forms like
+      // { label: 'United States' } or { index: 1 }.
+      let selectValue;
+      if (value == null) {
+        selectValue = '';
+      } else if (typeof value === 'object') {
+        selectValue = value; // array or { label/value/index } — pass through
+      } else {
+        selectValue = String(value);
+      }
       const strategies = looksLikeSelector(labelOrText)
         ? [p => p.locator(labelOrText)]
         : [
@@ -436,7 +447,7 @@ export function getSelfHealingHelperCode(healingHints) {
       await retry(async () => {
         const el = await findElement(page, strategies, { healingKey: 'select::' + labelOrText });
         await ensureReady(el);
-        await el.selectOption(strValue);
+        await el.selectOption(selectValue);
       });
     }
 

--- a/backend/src/selfHealing.js
+++ b/backend/src/selfHealing.js
@@ -731,8 +731,16 @@ export function applyHealingTransforms(code) {
       (match, arg) => `safeCheck(page, '${esc(arg)}')`
     )
     .replace(
+      /page\.locator\(['"`]([^'"`]+)['"`]\)\.check\(\)/g,
+      (match, sel) => looksLikeCssSelector(sel) ? match : `safeCheck(page, '${esc(sel)}')`
+    )
+    .replace(
       /page\.getByLabel\(['"`]([^'"`]+)['"`]\)\.uncheck\(\)/g,
       (match, arg) => `safeUncheck(page, '${esc(arg)}')`
+    )
+    .replace(
+      /page\.locator\(['"`]([^'"`]+)['"`]\)\.uncheck\(\)/g,
+      (match, sel) => looksLikeCssSelector(sel) ? match : `safeUncheck(page, '${esc(sel)}')`
     )
     .replace(
       /\bpage\.selectOption\(['"`]([^'"`]+)['"`],\s*([^)]+)\)/g,

--- a/backend/tests/api-test-prompt.test.js
+++ b/backend/tests/api-test-prompt.test.js
@@ -1,0 +1,169 @@
+/**
+ * @module tests/api-test-prompt
+ * @description Unit tests for formatJsonExample and buildApiTestPrompt.
+ *
+ * Coverage areas:
+ *   1. formatJsonExample — short strings, large arrays, large objects,
+ *      single-key overflow, non-JSON payloads, null/undefined input
+ *   2. buildApiTestPrompt — truncation integration via endpoint bodies
+ *
+ * Run: node tests/api-test-prompt.test.js
+ */
+
+import assert from "node:assert/strict";
+import { formatJsonExample } from "../src/pipeline/prompts/apiTestPrompt.js";
+
+// ── Test runner ───────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✅  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ❌  ${name}`);
+    console.log(`      ${err.message}`);
+    failed++;
+  }
+}
+
+// ── 1. formatJsonExample — basic behavior ────────────────────────────────────
+
+console.log("\n📦  formatJsonExample — basic behavior");
+
+test("returns short strings unchanged", () => {
+  const short = '{"name":"Alice","age":30}';
+  assert.equal(formatJsonExample(short), short);
+});
+
+test("returns empty string for null input", () => {
+  assert.equal(formatJsonExample(null), "");
+});
+
+test("returns empty string for undefined input", () => {
+  assert.equal(formatJsonExample(undefined), "");
+});
+
+test("returns empty string for empty string input", () => {
+  assert.equal(formatJsonExample(""), "");
+});
+
+test("returns non-string input as-is (truthy passthrough)", () => {
+  assert.equal(formatJsonExample(42), 42);
+});
+
+// ── 2. formatJsonExample — JSON array truncation ─────────────────────────────
+
+console.log("\n📦  formatJsonExample — JSON array truncation");
+
+test("truncates large arrays to fit within maxChars", () => {
+  // Create a large array with 50 objects
+  const arr = Array.from({ length: 50 }, (_, i) => ({ id: i, name: `Item number ${i}`, description: "A moderately long description for testing purposes" }));
+  const raw = JSON.stringify(arr);
+  assert.ok(raw.length > 200, "Test data should exceed maxChars");
+
+  const result = formatJsonExample(raw, 200);
+  assert.ok(result.length <= raw.length, "Result should be shorter than original");
+  const parsed = JSON.parse(result);
+  assert.ok(Array.isArray(parsed), "Result should be a valid JSON array");
+  assert.ok(parsed.length < arr.length, "Result should have fewer elements");
+});
+
+test("always includes at least one array element even if it exceeds maxChars", () => {
+  // Single large element that exceeds maxChars
+  const arr = [{ data: "x".repeat(500) }];
+  const raw = JSON.stringify(arr);
+  const result = formatJsonExample(raw, 100);
+  const parsed = JSON.parse(result);
+  assert.ok(Array.isArray(parsed), "Result should be a valid JSON array");
+  assert.equal(parsed.length, 1, "Should include at least one element");
+});
+
+// ── 3. formatJsonExample — JSON object truncation ────────────────────────────
+
+console.log("\n📦  formatJsonExample — JSON object truncation");
+
+test("truncates large objects by dropping keys that exceed maxChars", () => {
+  const obj = {};
+  for (let i = 0; i < 30; i++) {
+    obj[`key${i}`] = `value_${i}_${"x".repeat(20)}`;
+  }
+  const raw = JSON.stringify(obj);
+  assert.ok(raw.length > 300, "Test data should exceed maxChars");
+
+  const result = formatJsonExample(raw, 300);
+  const parsed = JSON.parse(result);
+  assert.ok(typeof parsed === "object" && !Array.isArray(parsed));
+  assert.ok(Object.keys(parsed).length < Object.keys(obj).length, "Should have fewer keys");
+  assert.ok(Object.keys(parsed).length >= 1, "Should have at least one key");
+});
+
+test("always includes at least one key even if first key exceeds maxChars", () => {
+  // Single key whose value is huge
+  const obj = { bigField: "x".repeat(5000) };
+  const raw = JSON.stringify(obj);
+  const result = formatJsonExample(raw, 100);
+  const parsed = JSON.parse(result);
+  assert.ok(typeof parsed === "object" && !Array.isArray(parsed));
+  assert.equal(Object.keys(parsed).length, 1, "Should include at least one key");
+  assert.ok("bigField" in parsed, "Should include the first key");
+});
+
+test("does not return empty {} for single-key object exceeding maxChars", () => {
+  const obj = { data: "y".repeat(3000) };
+  const raw = JSON.stringify(obj);
+  const result = formatJsonExample(raw, 100);
+  assert.notEqual(result, "{}", "Should never return empty object");
+});
+
+// ── 4. formatJsonExample — non-JSON payloads ─────────────────────────────────
+
+console.log("\n📦  formatJsonExample — non-JSON payloads");
+
+test("truncates non-JSON strings with [truncated] marker", () => {
+  const raw = "x".repeat(3000);
+  const result = formatJsonExample(raw, 200);
+  assert.ok(result.includes("... [truncated]"), "Should include truncated marker");
+  // The first 200 chars should be preserved
+  assert.ok(result.startsWith("x".repeat(200)), "Should start with original content");
+});
+
+test("non-JSON HTML payload is truncated with marker", () => {
+  const raw = "<html>" + "<div>content</div>".repeat(200) + "</html>";
+  const result = formatJsonExample(raw, 500);
+  assert.ok(result.includes("... [truncated]"));
+  assert.ok(result.length < raw.length);
+});
+
+// ── 5. formatJsonExample — maxChars parameter ────────────────────────────────
+
+console.log("\n📦  formatJsonExample — custom maxChars");
+
+test("respects custom maxChars for objects", () => {
+  const obj = { a: "short", b: "medium length value here", c: "another value that is longer" };
+  const raw = JSON.stringify(obj);
+  // With a very small maxChars, fewer keys should be included
+  const result = formatJsonExample(raw, 50);
+  const parsed = JSON.parse(result);
+  assert.ok(Object.keys(parsed).length >= 1, "Should include at least one key");
+  assert.ok(Object.keys(parsed).length <= Object.keys(obj).length);
+});
+
+test("returns string unchanged when under maxChars", () => {
+  const raw = JSON.stringify({ a: 1, b: 2 });
+  assert.equal(formatJsonExample(raw, 5000), raw);
+});
+
+// ── Results ───────────────────────────────────────────────────────────────────
+
+console.log(`\n${"─".repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed out of ${passed + failed} tests`);
+if (failed > 0) {
+  console.log(`\n⚠️  ${failed} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log(`\n🎉 All api-test-prompt tests passed!`);
+}

--- a/backend/tests/assertion-enhancer.test.js
+++ b/backend/tests/assertion-enhancer.test.js
@@ -410,8 +410,9 @@ console.log("\n🗂️  Snapshot fallback — sourceUrl and pageTitle used when 
 test("uses test.sourceUrl as snapshot.url when snapshotsByUrl is empty", () => {
   const t = noAssertTest({ sourceUrl: "http://myapp.com/login" });
   const { tests: result } = enhanceTests([t], {}, {});
-  // The injected URL assertion uses a hostname-only regex (per STABILITY_RULES)
-  assert.match(result[0].playwrightCode, /myapp\.com/);
+  // The injected URL assertion uses a hostname-only regex (per STABILITY_RULES).
+  // The dot is escaped in the generated regex literal: /myapp\\.com/i
+  assert.match(result[0].playwrightCode, /myapp\\\.com/);
 });
 
 test("uses test.pageTitle as snapshot.title when snapshotsByUrl is empty", () => {

--- a/backend/tests/assertion-enhancer.test.js
+++ b/backend/tests/assertion-enhancer.test.js
@@ -220,7 +220,7 @@ const TYPE_EXPECTATIONS = {
   e2e:           /toHaveTitle/,
   integration:   /locator\('form'\)/,
   accessibility: /locator\('main|h1/,
-  security:      /not\.toHaveURL/,
+  security:      /not\.toContainText/,
   performance:   /toHaveURL/,
 };
 
@@ -325,11 +325,11 @@ test("injects toHaveTitle when snapshot has a title", () => {
   assert.match(r.playwrightCode, /My Login Page/);
 });
 
-test("injects toHaveURL using the snapshot URL", () => {
+test("injects toHaveURL using the snapshot hostname", () => {
   const r = enhanceTest(noAssertTest(), SNAPSHOT, null);
-  // buildPageLoadAssertion always injects toHaveURL
-  // (may be overridden by template but URL should appear somewhere)
-  assert.match(r.playwrightCode, /http:\/\/ex\.com\/page/);
+  // buildPageLoadAssertion injects a hostname-only regex (per STABILITY_RULES)
+  assert.match(r.playwrightCode, /toHaveURL/);
+  assert.match(r.playwrightCode, /ex\.com/);
 });
 
 test("URL is JSON-stringified safely (handles special chars in URL)", () => {
@@ -410,8 +410,8 @@ console.log("\n🗂️  Snapshot fallback — sourceUrl and pageTitle used when 
 test("uses test.sourceUrl as snapshot.url when snapshotsByUrl is empty", () => {
   const t = noAssertTest({ sourceUrl: "http://myapp.com/login" });
   const { tests: result } = enhanceTests([t], {}, {});
-  // The injected URL assertion should use the test's sourceUrl
-  assert.match(result[0].playwrightCode, /myapp\.com\/login/);
+  // The injected URL assertion uses a hostname-only regex (per STABILITY_RULES)
+  assert.match(result[0].playwrightCode, /myapp\.com/);
 });
 
 test("uses test.pageTitle as snapshot.title when snapshotsByUrl is empty", () => {

--- a/backend/tests/feedback-loop.test.js
+++ b/backend/tests/feedback-loop.test.js
@@ -247,20 +247,29 @@ test("SELECTOR_ISSUE and URL_MISMATCH and TIMEOUT get priority='high'", () => {
   }
 });
 
-test("NAVIGATION_FAIL and ASSERTION_FAIL and UNKNOWN get priority='medium'", () => {
+test("NAVIGATION_FAIL and UNKNOWN get priority='medium'", () => {
   const mediumErrors = [
     { testId: "t1", status: "failed", error: "navigation failed: 503" },
-    { testId: "t2", status: "failed", error: "expect(received).toContainText(expected) received: 'x'" },
     { testId: "t3", status: "failed", error: "a completely unknown error" },
   ];
   const testMap = {
-    t1: makeTest("t1"), t2: makeTest("t2"), t3: makeTest("t3"),
+    t1: makeTest("t1"), t3: makeTest("t3"),
   };
   const { improvements } = analyzeRunResults(mediumErrors, testMap, {});
   for (const imp of improvements) {
     assert.equal(imp.priority, "medium",
       `${imp.failureCategory} should be medium priority, got ${imp.priority}`);
   }
+});
+
+test("ASSERTION_FAIL gets priority='high' (hard-coded values are prompt-quality issues)", () => {
+  const assertionErrors = [
+    { testId: "t1", status: "failed", error: "expect(received).toContainText(expected) received: 'x'" },
+  ];
+  const testMap = { t1: makeTest("t1") };
+  const { improvements } = analyzeRunResults(assertionErrors, testMap, {});
+  assert.equal(improvements[0].priority, "high",
+    `ASSERTION_FAIL should be high priority, got ${improvements[0].priority}`);
 });
 
 test("improvement object contains testId, test, failureCategory, errorMessage, priority", () => {

--- a/backend/tests/healing-transforms.test.js
+++ b/backend/tests/healing-transforms.test.js
@@ -657,6 +657,138 @@ for (const role of INPUT_ROLES) {
   });
 }
 
+// ── 15. safeCheck transforms ──────────────────────────────────────────────────
+
+console.log("\n☑️  safeCheck transforms");
+
+test("page.check('text') → safeCheck", () => {
+  const out = applyHealingTransforms("await page.check('Accept terms')");
+  assert.equal(out, "await safeCheck(page, 'Accept terms')");
+});
+
+test("page.check('#css') — CSS selector not rewritten", () => {
+  const code = "await page.check('#terms-checkbox')";
+  assert.equal(applyHealingTransforms(code), code);
+});
+
+test("page.getByLabel('x').check() → safeCheck", () => {
+  const out = applyHealingTransforms("await page.getByLabel('I agree').check()");
+  assert.equal(out, "await safeCheck(page, 'I agree')");
+});
+
+test("page.locator('text').check() with human text → safeCheck", () => {
+  const out = applyHealingTransforms("await page.locator('Newsletter').check()");
+  assert.equal(out, "await safeCheck(page, 'Newsletter')");
+});
+
+test("page.locator('#css').check() — CSS selector not rewritten", () => {
+  const code = "await page.locator('#newsletter-cb').check()";
+  assert.equal(applyHealingTransforms(code), code);
+});
+
+// ── 16. safeUncheck transforms ────────────────────────────────────────────────
+
+console.log("\n🔲  safeUncheck transforms");
+
+test("page.uncheck('text') → safeUncheck", () => {
+  const out = applyHealingTransforms("await page.uncheck('Accept terms')");
+  assert.equal(out, "await safeUncheck(page, 'Accept terms')");
+});
+
+test("page.uncheck('#css') — CSS selector not rewritten", () => {
+  const code = "await page.uncheck('#terms-checkbox')";
+  assert.equal(applyHealingTransforms(code), code);
+});
+
+test("page.getByLabel('x').uncheck() → safeUncheck", () => {
+  const out = applyHealingTransforms("await page.getByLabel('Subscribe').uncheck()");
+  assert.equal(out, "await safeUncheck(page, 'Subscribe')");
+});
+
+test("page.locator('text').uncheck() with human text → safeUncheck", () => {
+  const out = applyHealingTransforms("await page.locator('Notifications').uncheck()");
+  assert.equal(out, "await safeUncheck(page, 'Notifications')");
+});
+
+test("page.locator('#css').uncheck() — CSS selector not rewritten", () => {
+  const code = "await page.locator('#notify-cb').uncheck()";
+  assert.equal(applyHealingTransforms(code), code);
+});
+
+// ── 17. safeSelect transforms ─────────────────────────────────────────────────
+
+console.log("\n📋  safeSelect transforms");
+
+test("page.selectOption('text', val) → safeSelect", () => {
+  const out = applyHealingTransforms("await page.selectOption('Country', 'US')");
+  assert.equal(out, "await safeSelect(page, 'Country', 'US')");
+});
+
+test("page.selectOption('#css', val) — CSS selector not rewritten", () => {
+  const code = "await page.selectOption('#country-select', 'US')";
+  assert.equal(applyHealingTransforms(code), code);
+});
+
+test("page.getByLabel('x').selectOption(val) → safeSelect", () => {
+  const out = applyHealingTransforms("await page.getByLabel('Language').selectOption('en')");
+  assert.equal(out, "await safeSelect(page, 'Language', 'en')");
+});
+
+test("page.locator('text').selectOption(val) with human text → safeSelect", () => {
+  const out = applyHealingTransforms("await page.locator('Currency').selectOption('USD')");
+  assert.equal(out, "await safeSelect(page, 'Currency', 'USD')");
+});
+
+test("page.locator('#css').selectOption(val) — CSS selector not rewritten", () => {
+  const code = "await page.locator('#currency-sel').selectOption('USD')";
+  assert.equal(applyHealingTransforms(code), code);
+});
+
+// ── 18. safeCheck/safeUncheck/safeSelect idempotency ─────────────────────────
+
+console.log("\n🔁  safeCheck/safeUncheck/safeSelect idempotency");
+
+test("already-transformed safeCheck is not double-transformed", () => {
+  const already = "await safeCheck(page, 'Terms');";
+  assert.equal(applyHealingTransforms(already), already);
+});
+
+test("already-transformed safeUncheck is not double-transformed", () => {
+  const already = "await safeUncheck(page, 'Terms');";
+  assert.equal(applyHealingTransforms(already), already);
+});
+
+test("already-transformed safeSelect is not double-transformed", () => {
+  const already = "await safeSelect(page, 'Country', 'US');";
+  assert.equal(applyHealingTransforms(already), already);
+});
+
+// ── 19. Multi-line with check/uncheck/select ─────────────────────────────────
+
+console.log("\n📋  Multi-line with check/uncheck/select");
+
+test("transforms check/uncheck/selectOption in a full test body", () => {
+  const code = [
+    "await page.goto('http://app.com/settings');",
+    "await page.check('Enable notifications');",
+    "await page.uncheck('Marketing emails');",
+    "await page.selectOption('Timezone', 'UTC');",
+    "await page.click('Save');",
+  ].join("\n");
+
+  const out = applyHealingTransforms(code);
+
+  assert.match(out, /safeCheck\(page, 'Enable notifications'\)/);
+  assert.match(out, /safeUncheck\(page, 'Marketing emails'\)/);
+  assert.match(out, /safeSelect\(page, 'Timezone', 'UTC'\)/);
+  assert.match(out, /safeClick\(page, 'Save'\)/);
+  assert.doesNotMatch(out, /\bpage\.check\(/);
+  assert.doesNotMatch(out, /\bpage\.uncheck\(/);
+  assert.doesNotMatch(out, /\bpage\.selectOption\(/);
+  // page.goto must survive untouched
+  assert.match(out, /page\.goto/);
+});
+
 // ── Results ───────────────────────────────────────────────────────────────────
 
 console.log(`\n${"─".repeat(50)}`);

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -14,6 +14,7 @@ const files = [
   "tests/utils.test.js",
   "tests/test-fix.test.js",
   "tests/healing-transforms.test.js",
+  "tests/api-test-prompt.test.js",
   "tests/deduplicator.test.js",
   "tests/assertion-enhancer.test.js",
   "tests/test-validator.test.js",

--- a/backend/tests/self-healing.test.js
+++ b/backend/tests/self-healing.test.js
@@ -4,7 +4,7 @@
  */
 
 import assert from "node:assert/strict";
-import { getSelfHealingHelperCode } from "../src/selfHealing.js";
+import { getSelfHealingHelperCode, SELF_HEALING_PROMPT_RULES } from "../src/selfHealing.js";
 
 function test(name, fn) {
   try {
@@ -55,6 +55,96 @@ test("findElement uses firstVisible inside tryStrategy to skip hidden elements",
   assert.match(helpers, /return await firstVisible\(locator, timeout\)/);
   // .first() should only appear inside firstVisible's fallback, not in findElement directly
   assert.doesNotMatch(helpers, /strategies\[(?:hintIdx|i)\]\(page\)\.first\(\)/);
+});
+
+// ── New runtime helpers: safeSelect, safeCheck, safeUncheck ──────────────────
+
+console.log("\n🆕 new runtime helpers");
+
+test("safeSelect function is defined in runtime code", () => {
+  assert.match(helpers, /async function safeSelect\(page, labelOrText, value\)/);
+});
+
+test("safeCheck function is defined in runtime code", () => {
+  assert.match(helpers, /async function safeCheck\(page, labelOrText\)/);
+});
+
+test("safeUncheck function is defined in runtime code", () => {
+  assert.match(helpers, /async function safeUncheck\(page, labelOrText\)/);
+});
+
+test("safeSelect uses combobox and listbox strategies", () => {
+  assert.match(helpers, /getByRole\('combobox', \{ name: labelOrText \}\)/);
+  assert.match(helpers, /getByRole\('listbox', \{ name: labelOrText \}\)/);
+});
+
+test("safeCheck uses checkbox role strategy", () => {
+  assert.match(helpers, /getByRole\('checkbox', \{ name: labelOrText \}\)/);
+});
+
+test("safeSelect preserves object/array values (no coercion)", () => {
+  // The runtime code should have the typeof value === 'object' passthrough
+  assert.match(helpers, /typeof value === 'object'/);
+});
+
+// ── FIRST_VISIBLE_WAIT_CAP constant ──────────────────────────────────────────
+
+console.log("\n⏱️  FIRST_VISIBLE_WAIT_CAP");
+
+test("FIRST_VISIBLE_WAIT_CAP constant is injected into runtime code", () => {
+  assert.match(helpers, /const FIRST_VISIBLE_WAIT_CAP = \d+/);
+});
+
+test("firstVisible uses Math.min with FIRST_VISIBLE_WAIT_CAP", () => {
+  assert.match(helpers, /Math\.min\(timeout, FIRST_VISIBLE_WAIT_CAP\)/);
+});
+
+// ── Healing hints injection ──────────────────────────────────────────────────
+
+console.log("\n📝 healing hints injection");
+
+test("getSelfHealingHelperCode injects provided hints as JSON", () => {
+  const withHints = getSelfHealingHelperCode({ "click::Submit": 2, "fill::Email": 0 });
+  assert.match(withHints, /"click::Submit":2/);
+  assert.match(withHints, /"fill::Email":0/);
+});
+
+test("getSelfHealingHelperCode handles null gracefully", () => {
+  const withNull = getSelfHealingHelperCode(null);
+  assert.match(withNull, /__healingHints = \{\}/);
+});
+
+test("getSelfHealingHelperCode handles array gracefully", () => {
+  const withArray = getSelfHealingHelperCode([1, 2, 3]);
+  assert.match(withArray, /__healingHints = \{\}/);
+});
+
+// ── SELF_HEALING_PROMPT_RULES content ────────────────────────────────────────
+
+console.log("\n📜 SELF_HEALING_PROMPT_RULES content");
+
+test("SELF_HEALING_PROMPT_RULES mentions safeSelect", () => {
+  assert.match(SELF_HEALING_PROMPT_RULES, /safeSelect/);
+});
+
+test("SELF_HEALING_PROMPT_RULES mentions safeCheck", () => {
+  assert.match(SELF_HEALING_PROMPT_RULES, /safeCheck/);
+});
+
+test("SELF_HEALING_PROMPT_RULES mentions safeUncheck", () => {
+  assert.match(SELF_HEALING_PROMPT_RULES, /safeUncheck/);
+});
+
+test("SELF_HEALING_PROMPT_RULES lists page.check as forbidden", () => {
+  assert.match(SELF_HEALING_PROMPT_RULES, /page\.check/);
+});
+
+test("SELF_HEALING_PROMPT_RULES lists page.selectOption as forbidden", () => {
+  assert.match(SELF_HEALING_PROMPT_RULES, /page\.selectOption/);
+});
+
+test("SELF_HEALING_PROMPT_RULES lists page.locator().check as forbidden", () => {
+  assert.match(SELF_HEALING_PROMPT_RULES, /page\.locator\(\.\.\.\)\.check/);
 });
 
 if (process.exitCode) process.exit(1);


### PR DESCRIPTION
### Motivation

- Stale or repeatedly-failing healing hints caused the runtime to retry bad strategies and waste time, and the `firstVisible` fallback could wait the full timeout per strategy causing slow waterfalls.  
- Form-control interactions (`select`, `check`, `uncheck`) were forbidden by the prompt rules with no safe helpers, leaving the LLM unable to produce correct replacements.  
- AI prompts for API tests and feedback-driven fixes could lose critical context (truncated JSON bodies, missing DOM snapshot), causing hallucinations or fixes that revert to raw Playwright calls.  

### Description

- Added fail-aware hint gating and a visibility wait cap via `HEALING_HINT_MAX_FAILS` and `HEALING_VISIBLE_WAIT_CAP`, and used them in `getHealingHint`, `getHealingHistoryForTest`, and the injected runtime (`getSelfHealingHelperCode`) to reduce bad-hint retries and cap per-strategy waits.  
- Implemented new self-healing runtime helpers `safeSelect`, `safeCheck`, and `safeUncheck`, and extended `applyHealingTransforms` to rewrite raw `selectOption`, `check`, and `uncheck` usages into the safe helpers.  
- Scoped persisted healing history to test code version by using a `healingScopeId` like ``${test.id}@v${test.codeVersion || 0}`` at runtime, and updated `healingRepo.getByTestId` and `deleteByTestIds` to read/delete both legacy and versioned keys so older entries remain readable.  
- Improved prompt/context resilience by adding `formatJsonExample` to `buildApiTestPrompt` to preserve valid JSON examples (preventing mid-object truncation), injecting `SELF_HEALING_PROMPT_RULES` into the feedback-loop `buildImprovementPrompt`, and including a trimmed DOM snapshot excerpt in the `testFix` user prompt so fixes are grounded in failure-time page state.  

### Testing

- Ran `node tests/pipeline.test.js` and the suite passed.  
- Ran `node tests/self-healing.test.js` and `node tests/healing-transforms.test.js` and all new/related self-healing transform tests passed.  
- Ran `node tests/test-fix.test.js` and the `testFix` route checks passed with the new DOM snapshot inclusion.  
- Changes are backward-compatible with existing healing entries because repository access still reads legacy keys in addition to versioned keys.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1ac9850883269f1ba052aae300a2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rameshbabuprudhvi/sentri/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
