### PR TITLE
feat(acl): multi-tenancy workspaces and role-based access control

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,7 +174,7 @@ The following items have been verified complete against the codebase and are **n
 
 ### ACL-001 — Multi-tenancy: workspace ownership on all entities 🔴 Blocker
 
-**Status:** 🔲 Planned | **Effort:** L | **Source:** Audit
+**Status:** 🔄 In Progress | **Effort:** L | **Source:** Audit
 
 **Problem:** Every authenticated user sees every project, test, and run in the database. There is no workspace, organisation, or team concept. `GET /api/tests` returns all tests to any authenticated user. This is a hard blocker for any commercial deployment — companies must not see each other's test data.
 
@@ -194,7 +194,7 @@ The following items have been verified complete against the codebase and are **n
 
 ### ACL-002 — Role-based access control (Admin / QA Lead / Viewer) 🔴 Blocker
 
-**Status:** 🔲 Planned | **Effort:** M | **Source:** Audit
+**Status:** 🔄 In Progress | **Effort:** M | **Source:** Audit
 
 **Problem:** All authenticated users have identical permissions. Admin-only operations (settings, data deletion, user management) are only visually guarded on the frontend — the API accepts them from any authenticated user. Role separation is a hard requirement for any team deployment.
 

--- a/backend/src/database/migrations/004_workspaces_rbac.sql
+++ b/backend/src/database/migrations/004_workspaces_rbac.sql
@@ -1,0 +1,63 @@
+-- Migration 004: Workspaces + RBAC (ACL-001, ACL-002)
+--
+-- ACL-001 — Multi-tenancy: workspace ownership on all entities
+-- Adds a `workspaces` table and a `workspaceId` foreign key to projects,
+-- tests, runs, and activities.  All queries are scoped to the authenticated
+-- user's workspace so tenants cannot see each other's data.
+--
+-- ACL-002 — Role-based access control (Admin / QA Lead / Viewer)
+-- Adds a `workspace_members` join table with a `role` column.
+-- Roles: 'admin', 'qa_lead', 'viewer'.
+-- The first user in a workspace is automatically assigned 'admin'.
+--
+-- Existing data is assigned to a default workspace so the migration is
+-- non-breaking for current single-user deployments.
+
+-- ── workspaces table ───────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS workspaces (
+  id        TEXT PRIMARY KEY,           -- e.g. "WS-1"
+  name      TEXT NOT NULL,
+  slug      TEXT NOT NULL,              -- URL-friendly unique identifier
+  ownerId   TEXT NOT NULL,              -- references users(id) — workspace creator
+  createdAt TEXT NOT NULL,
+  updatedAt TEXT NOT NULL,
+  FOREIGN KEY (ownerId) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workspaces_slug ON workspaces(slug);
+
+-- ── workspace_members table (ACL-002) ──────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS workspace_members (
+  id          TEXT PRIMARY KEY,         -- e.g. "WM-1"
+  workspaceId TEXT NOT NULL,
+  userId      TEXT NOT NULL,
+  role        TEXT NOT NULL DEFAULT 'viewer',  -- 'admin' | 'qa_lead' | 'viewer'
+  joinedAt    TEXT NOT NULL,
+  FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE,
+  FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_wm_workspace_user ON workspace_members(workspaceId, userId);
+CREATE INDEX IF NOT EXISTS idx_wm_userId ON workspace_members(userId);
+
+-- Seed counters for workspace and member IDs
+INSERT OR IGNORE INTO counters(name, value) VALUES ('workspace', 0);
+INSERT OR IGNORE INTO counters(name, value) VALUES ('workspace_member', 0);
+
+-- ── Add workspaceId to existing entity tables ──────────────────────────────
+-- The column is nullable initially so existing rows are valid.  The
+-- application-level data backfill (in workspaceRepo.js ensureDefaultWorkspace)
+-- assigns all orphaned rows to the default workspace on first startup after
+-- this migration.
+
+ALTER TABLE projects ADD COLUMN workspaceId TEXT REFERENCES workspaces(id);
+ALTER TABLE tests ADD COLUMN workspaceId TEXT REFERENCES workspaces(id);
+ALTER TABLE runs ADD COLUMN workspaceId TEXT REFERENCES workspaces(id);
+ALTER TABLE activities ADD COLUMN workspaceId TEXT REFERENCES workspaces(id);
+
+CREATE INDEX IF NOT EXISTS idx_projects_workspaceId ON projects(workspaceId);
+CREATE INDEX IF NOT EXISTS idx_tests_workspaceId ON tests(workspaceId);
+CREATE INDEX IF NOT EXISTS idx_runs_workspaceId ON runs(workspaceId);
+CREATE INDEX IF NOT EXISTS idx_activities_workspaceId ON activities(workspaceId);

--- a/backend/src/database/repositories/activityRepo.js
+++ b/backend/src/database/repositories/activityRepo.js
@@ -7,13 +7,13 @@ import { getDatabase } from "../sqlite.js";
 
 /**
  * Create an activity entry.
- * @param {Object} activity — { id, type, projectId, projectName, testId, testName, detail, status, createdAt, userId?, userName? }
+ * @param {Object} activity — { id, type, projectId, projectName, testId, testName, detail, status, createdAt, userId?, userName?, workspaceId? }
  */
 export function create(activity) {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO activities (id, type, projectId, projectName, testId, testName, detail, status, createdAt, userId, userName)
-    VALUES (@id, @type, @projectId, @projectName, @testId, @testName, @detail, @status, @createdAt, @userId, @userName)
+    INSERT INTO activities (id, type, projectId, projectName, testId, testName, detail, status, createdAt, userId, userName, workspaceId)
+    VALUES (@id, @type, @projectId, @projectName, @testId, @testName, @detail, @status, @createdAt, @userId, @userName, @workspaceId)
   `).run({
     id: activity.id,
     type: activity.type,
@@ -26,6 +26,7 @@ export function create(activity) {
     createdAt: activity.createdAt,
     userId: activity.userId || null,
     userName: activity.userName || null,
+    workspaceId: activity.workspaceId || null,
   });
 }
 
@@ -54,13 +55,18 @@ export function getAllAsDict() {
  * @param {Object} [filters]
  * @param {string} [filters.type]
  * @param {string} [filters.projectId]
+ * @param {string} [filters.workspaceId] — Scope to workspace (ACL-001).
  * @param {number} [filters.limit=200]
  * @returns {Object[]}
  */
-export function getFiltered({ type, projectId, limit } = {}) {
+export function getFiltered({ type, projectId, workspaceId, limit } = {}) {
   const db = getDatabase();
   let sql = "SELECT * FROM activities WHERE 1=1";
   const params = [];
+  if (workspaceId) {
+    sql += " AND workspaceId = ?";
+    params.push(workspaceId);
+  }
   if (type) {
     sql += " AND type = ?";
     params.push(type);

--- a/backend/src/database/repositories/projectRepo.js
+++ b/backend/src/database/repositories/projectRepo.js
@@ -33,10 +33,14 @@ function projectToRow(p) {
 
 /**
  * Get all non-deleted projects.
+ * @param {string} [workspaceId] — If provided, scope to this workspace (ACL-001).
  * @returns {Object[]}
  */
-export function getAll() {
+export function getAll(workspaceId) {
   const db = getDatabase();
+  if (workspaceId) {
+    return db.prepare("SELECT * FROM projects WHERE deletedAt IS NULL AND workspaceId = ?").all(workspaceId).map(rowToProject);
+  }
   return db.prepare("SELECT * FROM projects WHERE deletedAt IS NULL").all().map(rowToProject);
 }
 
@@ -74,14 +78,15 @@ export function getById(id) {
 
 /**
  * Create a project.
- * @param {Object} project
+ * @param {Object} project — Must include `workspaceId` (ACL-001).
  */
 export function create(project) {
   const db = getDatabase();
   const row = projectToRow(project);
+  row.workspaceId = project.workspaceId || null;
   db.prepare(`
-    INSERT INTO projects (id, name, url, credentials, status, createdAt)
-    VALUES (@id, @name, @url, @credentials, @status, @createdAt)
+    INSERT INTO projects (id, name, url, credentials, status, createdAt, workspaceId)
+    VALUES (@id, @name, @url, @credentials, @status, @createdAt, @workspaceId)
   `).run(row);
 }
 
@@ -110,10 +115,14 @@ export function update(id, fields) {
 
 /**
  * Count total non-deleted projects.
+ * @param {string} [workspaceId] — If provided, scope to this workspace (ACL-001).
  * @returns {number}
  */
-export function count() {
+export function count(workspaceId) {
   const db = getDatabase();
+  if (workspaceId) {
+    return db.prepare("SELECT COUNT(*) as cnt FROM projects WHERE deletedAt IS NULL AND workspaceId = ?").get(workspaceId).cnt;
+  }
   return db.prepare("SELECT COUNT(*) as cnt FROM projects WHERE deletedAt IS NULL").get().cnt;
 }
 
@@ -139,10 +148,14 @@ export function hardDeleteById(id) {
 
 /**
  * Get all soft-deleted projects (recycle bin).
+ * @param {string} [workspaceId] — If provided, scope to this workspace (ACL-001).
  * @returns {Object[]}
  */
-export function getDeletedAll() {
+export function getDeletedAll(workspaceId) {
   const db = getDatabase();
+  if (workspaceId) {
+    return db.prepare("SELECT * FROM projects WHERE deletedAt IS NOT NULL AND workspaceId = ? ORDER BY deletedAt DESC").all(workspaceId).map(rowToProject);
+  }
   return db.prepare("SELECT * FROM projects WHERE deletedAt IS NOT NULL ORDER BY deletedAt DESC").all().map(rowToProject);
 }
 

--- a/backend/src/database/repositories/projectRepo.js
+++ b/backend/src/database/repositories/projectRepo.js
@@ -77,6 +77,21 @@ export function getById(id) {
 }
 
 /**
+ * Get a non-deleted project by ID, scoped to a workspace (ACL-001).
+ * Returns undefined if the project doesn't exist OR belongs to a different workspace.
+ * Use this in route handlers to prevent cross-workspace IDOR.
+ * @param {string} id
+ * @param {string} workspaceId
+ * @returns {Object|undefined}
+ */
+export function getByIdInWorkspace(id, workspaceId) {
+  const db = getDatabase();
+  return rowToProject(
+    db.prepare("SELECT * FROM projects WHERE id = ? AND workspaceId = ? AND deletedAt IS NULL").get(id, workspaceId)
+  );
+}
+
+/**
  * Create a project.
  * @param {Object} project — Must include `workspaceId` (ACL-001).
  */

--- a/backend/src/database/repositories/testRepo.js
+++ b/backend/src/database/repositories/testRepo.js
@@ -92,6 +92,46 @@ export function getAllPaged(page, pageSize) {
 }
 
 /**
+ * Get all non-deleted tests belonging to the given project IDs.
+ * Used by the workspace-scoped GET /api/tests endpoint (ACL-001).
+ * @param {string[]} projectIds
+ * @returns {Object[]}
+ */
+export function getAllByProjectIds(projectIds) {
+  if (!projectIds || projectIds.length === 0) return [];
+  const db = getDatabase();
+  const placeholders = projectIds.map(() => "?").join(", ");
+  return db.prepare(
+    `SELECT * FROM tests WHERE projectId IN (${placeholders}) AND deletedAt IS NULL`
+  ).all(...projectIds).map(rowToTest);
+}
+
+/**
+ * Get all non-deleted tests belonging to the given project IDs with pagination.
+ * Used by the workspace-scoped GET /api/tests endpoint (ACL-001).
+ * @param {string[]} projectIds
+ * @param {number|string} [page=1]
+ * @param {number|string} [pageSize=DEFAULT_PAGE_SIZE]
+ * @returns {PagedResult}
+ */
+export function getAllPagedByProjectIds(projectIds, page, pageSize) {
+  if (!projectIds || projectIds.length === 0) {
+    const { page: p, pageSize: ps } = parsePagination(page, pageSize);
+    return { data: [], meta: { total: 0, page: p, pageSize: ps, hasMore: false } };
+  }
+  const db = getDatabase();
+  const { page: p, pageSize: ps, offset } = parsePagination(page, pageSize);
+  const placeholders = projectIds.map(() => "?").join(", ");
+  const total = db.prepare(
+    `SELECT COUNT(*) as cnt FROM tests WHERE projectId IN (${placeholders}) AND deletedAt IS NULL`
+  ).get(...projectIds).cnt;
+  const data = db.prepare(
+    `SELECT * FROM tests WHERE projectId IN (${placeholders}) AND deletedAt IS NULL ORDER BY createdAt DESC LIMIT ? OFFSET ?`
+  ).all(...projectIds, ps, offset).map(rowToTest);
+  return { data, meta: { total, page: p, pageSize: ps, hasMore: offset + data.length < total } };
+}
+
+/**
  * Get all non-deleted tests as a dictionary keyed by ID.
  * @returns {Object<string, Object>}
  */

--- a/backend/src/database/repositories/workspaceRepo.js
+++ b/backend/src/database/repositories/workspaceRepo.js
@@ -236,8 +236,8 @@ export function ensureDefaultWorkspaces() {
     if (orphanUsers.length === 1) {
       // ── Single user: straightforward assignment ─────────────────────
       const user = orphanUsers[0];
-      const wsName = `${user.name}'s Workspace`;
-      const slug = `${slugify(user.name)}-${crypto.randomBytes(3).toString("hex")}`;
+      const wsName = `${user.name || "My"}'s Workspace`;
+      const slug = `${slugify(user.name || "user")}-${crypto.randomBytes(3).toString("hex")}`;
       const ws = create({ name: wsName, slug, ownerId: user.id });
 
       db.prepare("UPDATE projects SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
@@ -271,8 +271,8 @@ export function ensureDefaultWorkspaces() {
       for (const user of orphanUsers) {
         // Skip the first user — they already own the shared workspace
         if (user.id === orphanUsers[0].id) continue;
-        const slug = `${slugify(user.name)}-${crypto.randomBytes(3).toString("hex")}`;
-        create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
+        const slug = `${slugify(user.name || "user")}-${crypto.randomBytes(3).toString("hex")}`;
+        create({ name: `${user.name || "My"}'s Workspace`, slug, ownerId: user.id });
       }
     }
   });

--- a/backend/src/database/repositories/workspaceRepo.js
+++ b/backend/src/database/repositories/workspaceRepo.js
@@ -1,0 +1,237 @@
+/**
+ * @module database/repositories/workspaceRepo
+ * @description Workspace CRUD backed by SQLite (ACL-001).
+ *
+ * Each workspace is an isolated tenant.  All entity tables (projects, tests,
+ * runs, activities) carry a `workspaceId` foreign key so queries can be
+ * scoped to the authenticated user's workspace.
+ *
+ * ### Default workspace
+ * On first startup after migration 004, {@link ensureDefaultWorkspace} creates
+ * a "Default" workspace for every existing user and backfills `workspaceId`
+ * on all orphaned entity rows.  This makes the migration non-breaking for
+ * existing single-user deployments.
+ */
+
+import crypto from "crypto";
+import { getDatabase } from "../sqlite.js";
+import { generateWorkspaceId, generateWorkspaceMemberId } from "../../utils/idGenerator.js";
+
+// ─── Read ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Get a workspace by ID.
+ * @param {string} id
+ * @returns {Object|undefined}
+ */
+export function getById(id) {
+  const db = getDatabase();
+  return db.prepare("SELECT * FROM workspaces WHERE id = ?").get(id) || undefined;
+}
+
+/**
+ * Get a workspace by slug.
+ * @param {string} slug
+ * @returns {Object|undefined}
+ */
+export function getBySlug(slug) {
+  const db = getDatabase();
+  return db.prepare("SELECT * FROM workspaces WHERE slug = ?").get(slug) || undefined;
+}
+
+/**
+ * Get all workspaces for a user (via workspace_members).
+ * @param {string} userId
+ * @returns {Object[]}
+ */
+export function getByUserId(userId) {
+  const db = getDatabase();
+  return db.prepare(`
+    SELECT w.*, wm.role
+    FROM workspaces w
+    INNER JOIN workspace_members wm ON wm.workspaceId = w.id
+    WHERE wm.userId = ?
+    ORDER BY w.createdAt ASC
+  `).all(userId);
+}
+
+/**
+ * Get a user's membership in a specific workspace.
+ * @param {string} workspaceId
+ * @param {string} userId
+ * @returns {Object|undefined} — { id, workspaceId, userId, role, joinedAt }
+ */
+export function getMembership(workspaceId, userId) {
+  const db = getDatabase();
+  return db.prepare(
+    "SELECT * FROM workspace_members WHERE workspaceId = ? AND userId = ?"
+  ).get(workspaceId, userId) || undefined;
+}
+
+/**
+ * Get all members of a workspace.
+ * @param {string} workspaceId
+ * @returns {Object[]}
+ */
+export function getMembers(workspaceId) {
+  const db = getDatabase();
+  return db.prepare(`
+    SELECT wm.id, wm.workspaceId, wm.userId, wm.role, wm.joinedAt,
+           u.name, u.email, u.avatar
+    FROM workspace_members wm
+    INNER JOIN users u ON u.id = wm.userId
+    WHERE wm.workspaceId = ?
+    ORDER BY wm.joinedAt ASC
+  `).all(workspaceId);
+}
+
+// ─── Write ────────────────────────────────────────────────────────────────────
+
+/**
+ * Create a workspace and add the creator as admin.
+ * @param {Object} opts
+ * @param {string} opts.name     — Display name.
+ * @param {string} opts.slug     — URL-friendly identifier.
+ * @param {string} opts.ownerId  — User ID of the creator.
+ * @returns {Object} The created workspace.
+ */
+export function create({ name, slug, ownerId }) {
+  const db = getDatabase();
+  const now = new Date().toISOString();
+  const id = generateWorkspaceId();
+
+  db.prepare(`
+    INSERT INTO workspaces (id, name, slug, ownerId, createdAt, updatedAt)
+    VALUES (@id, @name, @slug, @ownerId, @createdAt, @updatedAt)
+  `).run({ id, name, slug, ownerId, createdAt: now, updatedAt: now });
+
+  // Add creator as admin member
+  addMember(id, ownerId, "admin");
+
+  return { id, name, slug, ownerId, createdAt: now, updatedAt: now };
+}
+
+/**
+ * Update workspace fields.
+ * @param {string} id
+ * @param {Object} fields — { name?, slug? }
+ */
+export function update(id, fields) {
+  const db = getDatabase();
+  const allowed = ["name", "slug"];
+  const sets = [];
+  const params = { id };
+  for (const key of allowed) {
+    if (key in fields) {
+      sets.push(`${key} = @${key}`);
+      params[key] = fields[key];
+    }
+  }
+  if (sets.length === 0) return;
+  sets.push("updatedAt = @updatedAt");
+  params.updatedAt = new Date().toISOString();
+  db.prepare(`UPDATE workspaces SET ${sets.join(", ")} WHERE id = @id`).run(params);
+}
+
+/**
+ * Add a user to a workspace with a given role.
+ * @param {string} workspaceId
+ * @param {string} userId
+ * @param {string} [role='viewer'] — 'admin' | 'qa_lead' | 'viewer'
+ * @returns {Object} The membership row.
+ */
+export function addMember(workspaceId, userId, role = "viewer") {
+  const db = getDatabase();
+  const id = generateWorkspaceMemberId();
+  const joinedAt = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO workspace_members (id, workspaceId, userId, role, joinedAt)
+    VALUES (@id, @workspaceId, @userId, @role, @joinedAt)
+  `).run({ id, workspaceId, userId, role, joinedAt });
+  return { id, workspaceId, userId, role, joinedAt };
+}
+
+/**
+ * Update a member's role.
+ * @param {string} workspaceId
+ * @param {string} userId
+ * @param {string} role — 'admin' | 'qa_lead' | 'viewer'
+ * @returns {boolean} Whether the membership was found and updated.
+ */
+export function updateMemberRole(workspaceId, userId, role) {
+  const db = getDatabase();
+  const info = db.prepare(
+    "UPDATE workspace_members SET role = ? WHERE workspaceId = ? AND userId = ?"
+  ).run(role, workspaceId, userId);
+  return info.changes > 0;
+}
+
+/**
+ * Remove a member from a workspace.
+ * @param {string} workspaceId
+ * @param {string} userId
+ * @returns {boolean} Whether the membership was found and removed.
+ */
+export function removeMember(workspaceId, userId) {
+  const db = getDatabase();
+  const info = db.prepare(
+    "DELETE FROM workspace_members WHERE workspaceId = ? AND userId = ?"
+  ).run(workspaceId, userId);
+  return info.changes > 0;
+}
+
+// ─── Default workspace backfill ───────────────────────────────────────────────
+
+/**
+ * Generate a URL-friendly slug from a name.
+ * @param {string} name
+ * @returns {string}
+ */
+function slugify(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    || "workspace";
+}
+
+/**
+ * Ensure every existing user has at least one workspace.
+ *
+ * Called once on startup after migration 004.  For each user without a
+ * workspace membership, creates a personal "My Workspace" workspace and
+ * assigns all their orphaned entities (projects with NULL workspaceId) to it.
+ *
+ * This is idempotent — calling it multiple times is safe.
+ */
+export function ensureDefaultWorkspaces() {
+  const db = getDatabase();
+
+  // Find users who are not members of any workspace
+  const orphanUsers = db.prepare(`
+    SELECT u.id, u.name FROM users u
+    WHERE NOT EXISTS (
+      SELECT 1 FROM workspace_members wm WHERE wm.userId = u.id
+    )
+  `).all();
+
+  if (orphanUsers.length === 0) return;
+
+  const txn = db.transaction(() => {
+    for (const user of orphanUsers) {
+      const wsName = `${user.name}'s Workspace`;
+      const baseSlug = slugify(user.name);
+      // Ensure slug uniqueness by appending a short random suffix
+      const slug = `${baseSlug}-${crypto.randomBytes(3).toString("hex")}`;
+
+      const ws = create({ name: wsName, slug, ownerId: user.id });
+
+      // Backfill all orphaned entities to this workspace
+      db.prepare("UPDATE projects SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
+      db.prepare("UPDATE tests SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
+      db.prepare("UPDATE runs SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
+      db.prepare("UPDATE activities SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
+    }
+  });
+  txn();
+}

--- a/backend/src/database/repositories/workspaceRepo.js
+++ b/backend/src/database/repositories/workspaceRepo.js
@@ -199,8 +199,23 @@ function slugify(name) {
  * Ensure every existing user has at least one workspace.
  *
  * Called once on startup after migration 004.  For each user without a
- * workspace membership, creates a personal "My Workspace" workspace and
- * assigns all their orphaned entities (projects with NULL workspaceId) to it.
+ * workspace membership, creates a personal workspace.
+ *
+ * ### Orphaned entity backfill
+ * Entities (projects, tests, runs) have no `userId` column, so there is no
+ * reliable way to attribute them to individual users.  The backfill strategy
+ * depends on how many orphan users exist:
+ *
+ * - **Single orphan user:** All orphaned entities are assigned to that user's
+ *   workspace.  This is the common case (single-user deployment upgrading).
+ * - **Multiple orphan users:** A shared "Default" workspace is created and
+ *   all orphaned entities are assigned there.  All orphan users are added as
+ *   members.  The first orphan user is the admin; the rest are viewers.
+ *   This prevents the first-user-claims-everything bug and preserves data
+ *   visibility for all existing users.
+ *
+ * Activities (which have `userId`) are always attributed to the correct
+ * user's workspace when possible.
  *
  * This is idempotent — calling it multiple times is safe.
  */
@@ -218,19 +233,47 @@ export function ensureDefaultWorkspaces() {
   if (orphanUsers.length === 0) return;
 
   const txn = db.transaction(() => {
-    for (const user of orphanUsers) {
+    if (orphanUsers.length === 1) {
+      // ── Single user: straightforward assignment ─────────────────────
+      const user = orphanUsers[0];
       const wsName = `${user.name}'s Workspace`;
-      const baseSlug = slugify(user.name);
-      // Ensure slug uniqueness by appending a short random suffix
-      const slug = `${baseSlug}-${crypto.randomBytes(3).toString("hex")}`;
-
+      const slug = `${slugify(user.name)}-${crypto.randomBytes(3).toString("hex")}`;
       const ws = create({ name: wsName, slug, ownerId: user.id });
 
-      // Backfill all orphaned entities to this workspace
       db.prepare("UPDATE projects SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
       db.prepare("UPDATE tests SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
       db.prepare("UPDATE runs SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
       db.prepare("UPDATE activities SET workspaceId = ? WHERE workspaceId IS NULL").run(ws.id);
+    } else {
+      // ── Multiple users: shared workspace for orphaned entities ──────
+      const sharedSlug = `default-${crypto.randomBytes(3).toString("hex")}`;
+      const sharedWs = create({ name: "Default Workspace", slug: sharedSlug, ownerId: orphanUsers[0].id });
+
+      // Add all other orphan users to the shared workspace
+      for (let i = 1; i < orphanUsers.length; i++) {
+        addMember(sharedWs.id, orphanUsers[i].id, "viewer");
+      }
+
+      // Assign all un-owned entities to the shared workspace
+      db.prepare("UPDATE projects SET workspaceId = ? WHERE workspaceId IS NULL").run(sharedWs.id);
+      db.prepare("UPDATE tests SET workspaceId = ? WHERE workspaceId IS NULL").run(sharedWs.id);
+      db.prepare("UPDATE runs SET workspaceId = ? WHERE workspaceId IS NULL").run(sharedWs.id);
+
+      // Activities have userId — attribute to the correct user's workspace
+      // where possible. Activities without a userId go to the shared workspace.
+      db.prepare("UPDATE activities SET workspaceId = ? WHERE workspaceId IS NULL AND userId IS NULL").run(sharedWs.id);
+
+      // For activities with a userId, they all go to the shared workspace
+      // too (since all users are members), but we set it explicitly.
+      db.prepare("UPDATE activities SET workspaceId = ? WHERE workspaceId IS NULL").run(sharedWs.id);
+
+      // Also create personal workspaces for each user (empty — for future use)
+      for (const user of orphanUsers) {
+        // Skip the first user — they already own the shared workspace
+        if (user.id === orphanUsers[0].id) continue;
+        const slug = `${slugify(user.name)}-${crypto.randomBytes(3).toString("hex")}`;
+        create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
+      }
     }
   });
   txn();

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,3 +1,0 @@
-// This file has been intentionally emptied.
-// All consumers have been migrated to use repository modules directly.
-// Safe to delete this file in a future cleanup.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -26,9 +26,11 @@ import { formatLogLine, structuredLog } from "./utils/logFormatter.js";
 import { loadKeysFromDatabase } from "./aiProvider.js";
 import { initScheduler, stopAllTasks } from "./scheduler.js";
 import { closeRedis } from "./utils/redisClient.js";
+import { ensureDefaultWorkspaces } from "./database/repositories/workspaceRepo.js";
 
 // ─── App + global middleware ──────────────────────────────────────────────────
 import { app } from "./middleware/appSetup.js";
+import { workspaceScope } from "./middleware/workspaceScope.js";
 
 // ─── Route modules ────────────────────────────────────────────────────────────
 import projectsRouter from "./routes/projects.js";
@@ -44,6 +46,7 @@ import { requireAuth } from "./routes/auth.js";
 import chatRouter from "./routes/chat.js";
 import testFixRouter from "./routes/testFix.js";
 import recycleBinRouter from "./routes/recycleBin.js";
+import workspacesRouter from "./routes/workspaces.js";
 
 // Re-export SSE symbols so existing imports from "./index.js" keep working
 // during incremental migration (runLogger.js, crawler.js, testRunner.js).
@@ -82,7 +85,10 @@ const orphanCount = runRepo.markOrphansInterrupted();
 if (orphanCount > 0) {
   console.warn(formatLogLine("warn", null, `[db] Marked ${orphanCount} orphaned run(s) as interrupted`));
 }
-// 5. Initialise cron-based test scheduler (ENH-006)
+// 5. Ensure every user has a workspace (ACL-001 backfill for existing data).
+//    Must run after DB init + migrations so the workspaces table exists.
+ensureDefaultWorkspaces();
+// 6. Initialise cron-based test scheduler (ENH-006)
 //    Must run after DB init so scheduleRepo can read the schedules table.
 initScheduler();
 
@@ -170,17 +176,19 @@ app.use("/api/auth", authRouter);
 // with a project token rather than a user JWT.
 app.use("/api", triggerRouter);
 
-// All other API routes require a valid JWT token
-app.use("/api/projects", requireAuth, projectsRouter);
-app.use("/api", requireAuth, testsRouter);
-app.use("/api", requireAuth, runsRouter);
-app.use("/api", requireAuth, sseRouter);
-app.use("/api", requireAuth, dashboardRouter);
-app.use("/api", requireAuth, settingsRouter);
-app.use("/api", requireAuth, systemRouter);
-app.use("/api", requireAuth, chatRouter);
-app.use("/api", requireAuth, testFixRouter);
-app.use("/api", requireAuth, recycleBinRouter);
+// All other API routes require a valid JWT token + workspace context (ACL-001).
+// workspaceScope injects req.workspaceId and req.userRole from the JWT or DB.
+app.use("/api/projects", requireAuth, workspaceScope, projectsRouter);
+app.use("/api", requireAuth, workspaceScope, testsRouter);
+app.use("/api", requireAuth, workspaceScope, runsRouter);
+app.use("/api", requireAuth, workspaceScope, sseRouter);
+app.use("/api", requireAuth, workspaceScope, dashboardRouter);
+app.use("/api", requireAuth, workspaceScope, settingsRouter);
+app.use("/api", requireAuth, workspaceScope, systemRouter);
+app.use("/api", requireAuth, workspaceScope, chatRouter);
+app.use("/api", requireAuth, workspaceScope, testFixRouter);
+app.use("/api", requireAuth, workspaceScope, recycleBinRouter);
+app.use("/api/workspaces", requireAuth, workspaceScope, workspacesRouter);
 
 // ─── Health probes (root-level, not under /api, no auth required) ────────────
 // GET /health  — liveness: is the process alive?

--- a/backend/src/middleware/requireRole.js
+++ b/backend/src/middleware/requireRole.js
@@ -1,0 +1,71 @@
+/**
+ * @module middleware/requireRole
+ * @description Role-based access control middleware (ACL-002).
+ *
+ * Creates Express middleware that checks `req.userRole` (injected by the
+ * workspace-aware auth flow in `authenticate.js`) against a minimum role
+ * level.
+ *
+ * ### Role hierarchy
+ * ```
+ * admin > qa_lead > viewer
+ * ```
+ *
+ * `requireRole('qa_lead')` allows `admin` and `qa_lead` but blocks `viewer`.
+ * `requireRole('admin')` allows only `admin`.
+ *
+ * ### Usage
+ * ```js
+ * import { requireRole } from "../middleware/requireRole.js";
+ *
+ * router.delete("/:id", requireRole("admin"), (req, res) => { … });
+ * router.post("/",      requireRole("qa_lead"), (req, res) => { … });
+ * ```
+ *
+ * @param {string} minimumRole — The minimum role required ('admin' | 'qa_lead' | 'viewer').
+ * @returns {Function} Express middleware `(req, res, next)`.
+ */
+
+/** Numeric weight per role — higher = more privileged. */
+const ROLE_WEIGHT = {
+  admin:   30,
+  qa_lead: 20,
+  viewer:  10,
+};
+
+/** Valid role names for input validation. */
+export const VALID_ROLES = new Set(Object.keys(ROLE_WEIGHT));
+
+/**
+ * Create an Express middleware that enforces a minimum role.
+ *
+ * Expects `req.userRole` to be set by the auth middleware.  If missing,
+ * returns 401.  If the role is below the minimum, returns 403.
+ *
+ * @param {string} minimumRole — 'admin' | 'qa_lead' | 'viewer'
+ * @returns {Function} Express middleware
+ */
+export function requireRole(minimumRole) {
+  const minWeight = ROLE_WEIGHT[minimumRole];
+  if (minWeight === undefined) {
+    throw new Error(`[requireRole] Unknown role: "${minimumRole}". Valid roles: ${[...VALID_ROLES].join(", ")}`);
+  }
+
+  return (req, res, next) => {
+    const userRole = req.userRole;
+    if (!userRole) {
+      return res.status(401).json({ error: "Authentication required." });
+    }
+
+    const userWeight = ROLE_WEIGHT[userRole];
+    if (userWeight === undefined || userWeight < minWeight) {
+      return res.status(403).json({
+        error: `This action requires ${minimumRole} permissions.`,
+        requiredRole: minimumRole,
+        currentRole: userRole || "unknown",
+      });
+    }
+
+    next();
+  };
+}

--- a/backend/src/middleware/workspaceScope.js
+++ b/backend/src/middleware/workspaceScope.js
@@ -6,10 +6,11 @@
  * Must run AFTER `requireAuth` (which sets `req.authUser`).
  *
  * ### Resolution strategy
- * 1. If the JWT payload contains `workspaceId` and `workspaceRole`, use those
- *    (fast path — no DB query on every request).
- * 2. Otherwise, look up the user's first workspace membership in the DB
- *    (fallback for tokens issued before ACL-001).
+ * The JWT contains `workspaceId` as a hint for which workspace the user last
+ * used.  The **role is always resolved from the database** so that permission
+ * changes (promote / demote / remove) take effect immediately — not after the
+ * JWT expires.  This follows the Slack / GitHub model: identity in the token,
+ * authorization from the DB.
  *
  * If the user has no workspace membership at all, returns 403.
  *
@@ -31,16 +32,22 @@ export function workspaceScope(req, res, next) {
   // Skip for non-user auth strategies (e.g. trigger tokens)
   if (!req.authUser) return next();
 
-  const { sub: userId, workspaceId, workspaceRole } = req.authUser;
+  const { sub: userId, workspaceId: jwtWorkspaceId } = req.authUser;
 
-  // Fast path: workspace info is in the JWT
-  if (workspaceId && workspaceRole) {
-    req.workspaceId = workspaceId;
-    req.userRole = workspaceRole;
-    return next();
+  // If the JWT contains a workspaceId hint, verify membership and resolve
+  // the current role from the DB (never trust the JWT for authorization).
+  if (jwtWorkspaceId) {
+    const membership = workspaceRepo.getMembership(jwtWorkspaceId, userId);
+    if (membership) {
+      req.workspaceId = jwtWorkspaceId;
+      req.userRole = membership.role;
+      return next();
+    }
+    // Membership was revoked since the JWT was issued — fall through to
+    // check if the user has any other workspace.
   }
 
-  // Fallback: look up membership in DB (tokens issued before ACL-001)
+  // Resolve from all memberships (no JWT hint, or hint was stale).
   const workspaces = workspaceRepo.getByUserId(userId);
   if (!workspaces || workspaces.length === 0) {
     return res.status(403).json({
@@ -48,7 +55,7 @@ export function workspaceScope(req, res, next) {
     });
   }
 
-  // Use the first workspace (default). Future: allow workspace switching.
+  // Use the first workspace. Future: allow workspace switching via header.
   const ws = workspaces[0];
   req.workspaceId = ws.id;
   req.userRole = ws.role;

--- a/backend/src/middleware/workspaceScope.js
+++ b/backend/src/middleware/workspaceScope.js
@@ -1,0 +1,56 @@
+/**
+ * @module middleware/workspaceScope
+ * @description Middleware that resolves the authenticated user's workspace
+ * and role, injecting `req.workspaceId` and `req.userRole` on every request.
+ *
+ * Must run AFTER `requireAuth` (which sets `req.authUser`).
+ *
+ * ### Resolution strategy
+ * 1. If the JWT payload contains `workspaceId` and `workspaceRole`, use those
+ *    (fast path — no DB query on every request).
+ * 2. Otherwise, look up the user's first workspace membership in the DB
+ *    (fallback for tokens issued before ACL-001).
+ *
+ * If the user has no workspace membership at all, returns 403.
+ *
+ * @example
+ * import { workspaceScope } from "../middleware/workspaceScope.js";
+ * app.use("/api/projects", requireAuth, workspaceScope, projectsRouter);
+ */
+
+import * as workspaceRepo from "../database/repositories/workspaceRepo.js";
+
+/**
+ * Express middleware that injects workspace context onto the request.
+ *
+ * Sets:
+ * - `req.workspaceId` — The active workspace ID.
+ * - `req.userRole`    — The user's role in that workspace ('admin' | 'qa_lead' | 'viewer').
+ */
+export function workspaceScope(req, res, next) {
+  // Skip for non-user auth strategies (e.g. trigger tokens)
+  if (!req.authUser) return next();
+
+  const { sub: userId, workspaceId, workspaceRole } = req.authUser;
+
+  // Fast path: workspace info is in the JWT
+  if (workspaceId && workspaceRole) {
+    req.workspaceId = workspaceId;
+    req.userRole = workspaceRole;
+    return next();
+  }
+
+  // Fallback: look up membership in DB (tokens issued before ACL-001)
+  const workspaces = workspaceRepo.getByUserId(userId);
+  if (!workspaces || workspaces.length === 0) {
+    return res.status(403).json({
+      error: "You are not a member of any workspace. Please contact your administrator.",
+    });
+  }
+
+  // Use the first workspace (default). Future: allow workspace switching.
+  const ws = workspaces[0];
+  req.workspaceId = ws.id;
+  req.userRole = ws.role;
+  next();
+}

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -303,7 +303,7 @@ function ensureUserWorkspace(user) {
   const existing = workspaceRepo.getByUserId(user.id);
   if (existing && existing.length > 0) return;
   const slug = `${(user.name || "user").toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
-  workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
+  workspaceRepo.create({ name: `${user.name || "My"}'s Workspace`, slug, ownerId: user.id });
 }
 
 /**
@@ -884,7 +884,7 @@ router.get("/google/callback", async (req, res) => {
       provider: "google",
       providerId: profile.sub,
       email: profile.email.toLowerCase(),
-      name: profile.name,
+      name: profile.name || profile.email.split("@")[0],
       avatar: profile.picture || null,
     });
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -37,6 +37,7 @@ import crypto from "crypto";
 import * as userRepo from "../database/repositories/userRepo.js";
 import * as resetTokenRepo from "../database/repositories/passwordResetTokenRepo.js";
 import * as verificationTokenRepo from "../database/repositories/verificationTokenRepo.js";
+import * as workspaceRepo from "../database/repositories/workspaceRepo.js";
 import { formatLogLine } from "../utils/logFormatter.js";
 import { sendVerificationEmail } from "../utils/emailSender.js";
 import { cookieSameSite } from "../middleware/appSetup.js";
@@ -261,6 +262,49 @@ function validatePasswordStrength(password) {
   return null;
 }
 
+// ─── Workspace-aware JWT builder (ACL-001) ───────────────────────────────────
+
+/**
+ * Build a JWT payload that includes workspace context.
+ * Looks up the user's first workspace membership and includes `workspaceId`
+ * and `workspaceRole` in the token so the `workspaceScope` middleware can
+ * resolve them without a DB query on every request.
+ *
+ * @param {Object} user — User row from the database.
+ * @returns {{ sub, email, name, role, workspaceId, workspaceRole, jti }}
+ */
+function buildJwtPayload(user) {
+  const jti = crypto.randomUUID();
+  const payload = { sub: user.id, email: user.email, name: user.name, role: user.role, jti };
+
+  // Resolve workspace membership
+  const workspaces = workspaceRepo.getByUserId(user.id);
+  if (workspaces && workspaces.length > 0) {
+    payload.workspaceId = workspaces[0].id;
+    payload.workspaceRole = workspaces[0].role;
+  }
+
+  return payload;
+}
+
+/**
+ * Build the user response object with workspace info for the frontend.
+ * @param {Object} user — User row from the database.
+ * @returns {Object}
+ */
+function buildUserResponse(user) {
+  const resp = { id: user.id, name: user.name, email: user.email, role: user.role, avatar: user.avatar || null };
+
+  const workspaces = workspaceRepo.getByUserId(user.id);
+  if (workspaces && workspaces.length > 0) {
+    resp.workspaceId = workspaces[0].id;
+    resp.workspaceName = workspaces[0].name;
+    resp.workspaceRole = workspaces[0].role;
+  }
+
+  return resp;
+}
+
 // ─── Routes ──────────────────────────────────────────────────────────────────
 
 /**
@@ -382,8 +426,16 @@ router.post("/login", async (req, res) => {
       });
     }
 
-    const jti   = crypto.randomUUID();
-    const token = signJwt({ sub: user.id, email: user.email, name: user.name, role: user.role, jti }, getJwtSecret());
+    // ACL-001: Ensure the user has a workspace (may not if they registered
+    // before migration 004 and ensureDefaultWorkspaces didn't cover them).
+    const userWorkspaces = workspaceRepo.getByUserId(user.id);
+    if (!userWorkspaces || userWorkspaces.length === 0) {
+      const slug = `${user.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
+      workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
+    }
+
+    const payload = buildJwtPayload(user);
+    const token = signJwt(payload, getJwtSecret());
     const exp   = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
 
     setAuthCookie(res, token, exp);
@@ -391,9 +443,7 @@ router.post("/login", async (req, res) => {
     // Note: token is NOT returned in the response body — it lives in the HttpOnly
     // cookie only. The frontend reads user profile from this response and stores
     // it in React state. The token_exp cookie exposes the expiry timestamp.
-    return res.json({
-      user: { id: user.id, name: user.name, email: user.email, role: user.role, avatar: user.avatar || null },
-    });
+    return res.json({ user: buildUserResponse(user) });
   } catch (err) {
     console.error(formatLogLine("error", null, `[auth/login] ${err.message}`));
     return res.status(500).json({ error: "Sign-in failed. Please try again." });
@@ -427,7 +477,7 @@ router.post("/logout", requireAuth, (req, res) => {
 router.get("/me", requireAuth, (req, res) => {
   const user = userRepo.getById(req.authUser.sub);
   if (!user) return res.status(404).json({ error: "User not found." });
-  return res.json({ id: user.id, name: user.name, email: user.email, role: user.role, avatar: user.avatar || null, createdAt: user.createdAt });
+  return res.json({ ...buildUserResponse(user), createdAt: user.createdAt });
 });
 
 /**
@@ -450,15 +500,13 @@ router.post("/refresh", requireAuth, (req, res) => {
   const { jti: oldJti, exp: oldExp } = req.authUser;
   if (oldJti) revokedTokens.set(oldJti, oldExp);
 
-  // Issue a fresh token with a new JTI
-  const jti   = crypto.randomUUID();
-  const token = signJwt({ sub: user.id, email: user.email, name: user.name, role: user.role, jti }, getJwtSecret());
+  // Issue a fresh token with a new JTI (includes updated workspace context)
+  const payload = buildJwtPayload(user);
+  const token = signJwt(payload, getJwtSecret());
   const exp   = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
   setAuthCookie(res, token, exp);
 
-  return res.json({
-    user: { id: user.id, name: user.name, email: user.email, role: user.role, avatar: user.avatar || null },
-  });
+  return res.json({ user: buildUserResponse(user) });
 });
 
 // ─── Email Verification (SEC-001) ────────────────────────────────────────────
@@ -759,14 +807,19 @@ router.get("/github/callback", async (req, res) => {
       avatar: profile.avatar_url || null,
     });
 
-    const jti   = crypto.randomUUID();
-    const token = signJwt({ sub: user.id, email: user.email, name: user.name, role: user.role, jti }, getJwtSecret());
+    // ACL-001: Ensure workspace exists for OAuth users
+    const userWorkspaces = workspaceRepo.getByUserId(user.id);
+    if (!userWorkspaces || userWorkspaces.length === 0) {
+      const slug = `${(user.name || "user").toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
+      workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
+    }
+
+    const payload = buildJwtPayload(user);
+    const token = signJwt(payload, getJwtSecret());
     const exp   = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
     setAuthCookie(res, token, exp);
 
-    return res.json({
-      user: { id: user.id, name: user.name, email: user.email, role: user.role, avatar: user.avatar || null },
-    });
+    return res.json({ user: buildUserResponse(user) });
   } catch (err) {
     console.error(formatLogLine("error", null, `[auth/github] ${err.message}`));
     return res.status(401).json({ error: err.message || "GitHub authentication failed." });
@@ -826,14 +879,19 @@ router.get("/google/callback", async (req, res) => {
       avatar: profile.picture || null,
     });
 
-    const jti   = crypto.randomUUID();
-    const token = signJwt({ sub: user.id, email: user.email, name: user.name, role: user.role, jti }, getJwtSecret());
+    // ACL-001: Ensure workspace exists for OAuth users
+    const userWorkspaces = workspaceRepo.getByUserId(user.id);
+    if (!userWorkspaces || userWorkspaces.length === 0) {
+      const slug = `${(user.name || "user").toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
+      workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
+    }
+
+    const payload = buildJwtPayload(user);
+    const token = signJwt(payload, getJwtSecret());
     const exp   = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
     setAuthCookie(res, token, exp);
 
-    return res.json({
-      user: { id: user.id, name: user.name, email: user.email, role: user.role, avatar: user.avatar || null },
-    });
+    return res.json({ user: buildUserResponse(user) });
   } catch (err) {
     console.error(formatLogLine("error", null, `[auth/google] ${err.message}`));
     return res.status(401).json({ error: err.message || "Google authentication failed." });

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -265,26 +265,45 @@ function validatePasswordStrength(password) {
 // ─── Workspace-aware JWT builder (ACL-001) ───────────────────────────────────
 
 /**
- * Build a JWT payload that includes workspace context.
- * Looks up the user's first workspace membership and includes `workspaceId`
- * and `workspaceRole` in the token so the `workspaceScope` middleware can
- * resolve them without a DB query on every request.
+ * Build a JWT payload with a workspace hint.
+ *
+ * The JWT carries `workspaceId` as a **hint** so the `workspaceScope`
+ * middleware can look up the correct workspace without scanning all
+ * memberships.  The **role is never stored in the JWT** — it is always
+ * resolved from the `workspace_members` table at request time so that
+ * permission changes (promote / demote / remove) take effect immediately.
+ *
+ * This follows the Slack / GitHub model: identity in the token,
+ * authorization from the database.
  *
  * @param {Object} user — User row from the database.
- * @returns {{ sub, email, name, role, workspaceId, workspaceRole, jti }}
+ * @returns {{ sub, email, name, role, workspaceId, jti }}
  */
 function buildJwtPayload(user) {
   const jti = crypto.randomUUID();
   const payload = { sub: user.id, email: user.email, name: user.name, role: user.role, jti };
 
-  // Resolve workspace membership
+  // Include workspaceId as a routing hint (not for authorization)
   const workspaces = workspaceRepo.getByUserId(user.id);
   if (workspaces && workspaces.length > 0) {
     payload.workspaceId = workspaces[0].id;
-    payload.workspaceRole = workspaces[0].role;
   }
 
   return payload;
+}
+
+/**
+ * Ensure the user belongs to at least one workspace, creating a personal
+ * workspace if needed.  Called from every auth path (login, OAuth) so no
+ * user can end up without a workspace.
+ *
+ * @param {Object} user — User row from the database.
+ */
+function ensureUserWorkspace(user) {
+  const existing = workspaceRepo.getByUserId(user.id);
+  if (existing && existing.length > 0) return;
+  const slug = `${(user.name || "user").toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
+  workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
 }
 
 /**
@@ -426,13 +445,8 @@ router.post("/login", async (req, res) => {
       });
     }
 
-    // ACL-001: Ensure the user has a workspace (may not if they registered
-    // before migration 004 and ensureDefaultWorkspaces didn't cover them).
-    const userWorkspaces = workspaceRepo.getByUserId(user.id);
-    if (!userWorkspaces || userWorkspaces.length === 0) {
-      const slug = `${user.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
-      workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
-    }
+    // ACL-001: Ensure the user has a workspace before issuing a token.
+    ensureUserWorkspace(user);
 
     const payload = buildJwtPayload(user);
     const token = signJwt(payload, getJwtSecret());
@@ -807,12 +821,7 @@ router.get("/github/callback", async (req, res) => {
       avatar: profile.avatar_url || null,
     });
 
-    // ACL-001: Ensure workspace exists for OAuth users
-    const userWorkspaces = workspaceRepo.getByUserId(user.id);
-    if (!userWorkspaces || userWorkspaces.length === 0) {
-      const slug = `${(user.name || "user").toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
-      workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
-    }
+    ensureUserWorkspace(user);
 
     const payload = buildJwtPayload(user);
     const token = signJwt(payload, getJwtSecret());
@@ -879,12 +888,7 @@ router.get("/google/callback", async (req, res) => {
       avatar: profile.picture || null,
     });
 
-    // ACL-001: Ensure workspace exists for OAuth users
-    const userWorkspaces = workspaceRepo.getByUserId(user.id);
-    if (!userWorkspaces || userWorkspaces.length === 0) {
-      const slug = `${(user.name || "user").toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${crypto.randomBytes(3).toString("hex")}`;
-      workspaceRepo.create({ name: `${user.name}'s Workspace`, slug, ownerId: user.id });
-    }
+    ensureUserWorkspace(user);
 
     const payload = buildJwtPayload(user);
     const token = signJwt(payload, getJwtSecret());

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -19,14 +19,22 @@ import { classifyFailure } from "../pipeline/feedbackLoop.js";
 const router = Router();
 
 router.get("/dashboard", (req, res) => {
-  const projects = projectRepo.getAll();
+  // ACL-001: Scope dashboard data to the user's workspace.
+  // Projects are filtered by workspaceId; runs and tests are filtered by
+  // the set of project IDs that belong to this workspace.
+  const projects = projectRepo.getAll(req.workspaceId);
+  const projectIds = new Set(projects.map(p => p.id));
+
   // Use lean queries — dashboard only needs scalar fields + results for failure analysis.
   // Skipping logs, testQueue, generateInput, promptAudit, videoSegments saves ~10-50×
   // in JSON parse time compared to runRepo.getAll().
-  const runs = runRepo.getAllWithResults();
-  const tests = testRepo.getAll();
+  const allRuns = runRepo.getAllWithResults();
+  const runs = allRuns.filter(r => projectIds.has(r.projectId));
+  const allTests = testRepo.getAll();
+  const tests = allTests.filter(t => projectIds.has(t.projectId));
   // Only fetch activity types needed for dashboard counters (not all activities)
-  const generationActivities = activityRepo.getByTypes(["test.create", "test.generate"]);
+  const allGenerationActivities = activityRepo.getByTypes(["test.create", "test.generate"]);
+  const generationActivities = allGenerationActivities.filter(a => !a.projectId || projectIds.has(a.projectId));
   const projectsById = {};
   for (const p of projects) projectsById[p.id] = p;
 

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -52,6 +52,7 @@ router.post("/", (req, res) => {
     credentials: encryptCredentials(credentials) || null,
     createdAt: new Date().toISOString(),
     status: "idle",
+    workspaceId: req.workspaceId || null,
   };
   projectRepo.create(project);
 
@@ -64,7 +65,7 @@ router.post("/", (req, res) => {
 });
 
 router.get("/", (req, res) => {
-  res.json(projectRepo.getAll().map(sanitiseProjectForClient));
+  res.json(projectRepo.getAll(req.workspaceId).map(sanitiseProjectForClient));
 });
 
 router.get("/:id", (req, res) => {

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -69,13 +69,13 @@ router.get("/", (req, res) => {
 });
 
 router.get("/:id", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "not found" });
   res.json(sanitiseProjectForClient(project));
 });
 
 router.delete("/:id", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "not found" });
 
   // Refuse soft-deletion while async operations are in progress
@@ -137,7 +137,7 @@ router.delete("/:id", (req, res) => {
  * Return the current schedule for a project, or null if none exists.
  */
 router.get("/:id/schedule", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "Project not found" });
   const schedule = scheduleRepo.getByProjectId(req.params.id);
   res.json({ schedule: schedule || null });
@@ -153,7 +153,7 @@ router.get("/:id/schedule", (req, res) => {
  *   enabled  {boolean} - Whether the schedule is active (default true)
  */
 router.patch("/:id/schedule", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "Project not found" });
 
   const { cronExpr, timezone = "UTC", enabled = true } = req.body || {};
@@ -213,7 +213,7 @@ router.patch("/:id/schedule", (req, res) => {
  * Remove the cron schedule for a project entirely.
  */
 router.delete("/:id/schedule", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "Project not found" });
 
   const existing = scheduleRepo.getByProjectId(req.params.id);

--- a/backend/src/routes/recycleBin.js
+++ b/backend/src/routes/recycleBin.js
@@ -34,9 +34,15 @@ const router = Router();
  */
 router.get("/recycle-bin", (req, res) => {
   const LIMIT = 200;
-  const projects = projectRepo.getDeletedAll().slice(0, LIMIT).map(sanitiseProjectForClient);
-  const tests    = testRepo.getDeletedAll().slice(0, LIMIT);
-  const runs     = runRepo.getDeletedAll().slice(0, LIMIT);
+  // ACL-001: Scope recycle bin to the user's workspace.
+  const projects = projectRepo.getDeletedAll(req.workspaceId).slice(0, LIMIT).map(sanitiseProjectForClient);
+  const deletedProjectIds = new Set(projects.map(p => p.id));
+  // Also include project IDs from live projects in this workspace so we can
+  // show deleted tests/runs that belong to non-deleted workspace projects.
+  const liveProjects = projectRepo.getAll(req.workspaceId);
+  const allProjectIds = new Set([...deletedProjectIds, ...liveProjects.map(p => p.id)]);
+  const tests    = testRepo.getDeletedAll().filter(t => allProjectIds.has(t.projectId)).slice(0, LIMIT);
+  const runs     = runRepo.getDeletedAll().filter(r => allProjectIds.has(r.projectId)).slice(0, LIMIT);
   res.json({ projects, tests, runs });
 });
 
@@ -49,10 +55,14 @@ router.post("/restore/:type/:id", (req, res) => {
   let restored = false;
 
   if (type === "project") {
+    // ACL-001: Verify the project belongs to the user's workspace.
+    const projectBefore = projectRepo.getByIdIncludeDeleted(id);
+    if (!projectBefore || projectBefore.workspaceId !== req.workspaceId) {
+      return res.status(404).json({ error: "not found or not in recycle bin" });
+    }
     // Capture the project's deletedAt before restoring so we can scope the
     // cascade to only children deleted at the same time (or later).  Items
     // individually deleted *before* the project are left in the recycle bin.
-    const projectBefore = projectRepo.getByIdIncludeDeleted(id);
     restored = projectRepo.restore(id);
     if (restored) {
       const deletedAt = projectBefore?.deletedAt;
@@ -69,6 +79,11 @@ router.post("/restore/:type/:id", (req, res) => {
   } else if (type === "test") {
     const test = testRepo.getByIdIncludeDeleted(id);
     if (test) {
+      // ACL-001: Verify the test's project belongs to the user's workspace.
+      const parentProjectFull = projectRepo.getByIdIncludeDeleted(test.projectId);
+      if (!parentProjectFull || parentProjectFull.workspaceId !== req.workspaceId) {
+        return res.status(404).json({ error: "not found or not in recycle bin" });
+      }
       const parentProject = projectRepo.getById(test.projectId);
       if (!parentProject) {
         return res.status(409).json({ error: "Parent project is deleted — restore the project first" });
@@ -84,6 +99,11 @@ router.post("/restore/:type/:id", (req, res) => {
   } else if (type === "run") {
     const run = runRepo.getByIdIncludeDeleted(id);
     if (run) {
+      // ACL-001: Verify the run's project belongs to the user's workspace.
+      const parentProjectFull = projectRepo.getByIdIncludeDeleted(run.projectId);
+      if (!parentProjectFull || parentProjectFull.workspaceId !== req.workspaceId) {
+        return res.status(404).json({ error: "not found or not in recycle bin" });
+      }
       const parentProject = projectRepo.getById(run.projectId);
       if (!parentProject) {
         return res.status(409).json({ error: "Parent project is deleted — restore the project first" });
@@ -116,6 +136,10 @@ router.delete("/purge/:type/:id", (req, res) => {
     if (!project || !project.deletedAt) {
       return res.status(404).json({ error: "not found in recycle bin" });
     }
+    // ACL-001: Verify the project belongs to the user's workspace.
+    if (project.workspaceId !== req.workspaceId) {
+      return res.status(404).json({ error: "not found in recycle bin" });
+    }
     const testIds = testRepo.hardDeleteByProjectId(id);
     if (testIds.length > 0) healingRepo.deleteByTestIds(testIds);
     runRepo.hardDeleteByProjectId(id);
@@ -133,6 +157,11 @@ router.delete("/purge/:type/:id", (req, res) => {
     if (!test || !test.deletedAt) {
       return res.status(404).json({ error: "not found in recycle bin" });
     }
+    // ACL-001: Verify the test's project belongs to the user's workspace.
+    const testProject = projectRepo.getByIdIncludeDeleted(test.projectId);
+    if (!testProject || testProject.workspaceId !== req.workspaceId) {
+      return res.status(404).json({ error: "not found in recycle bin" });
+    }
     healingRepo.deleteByTestIds([id]);
     testRepo.hardDeleteById(id);
     logActivity({ ...actor(req),
@@ -142,6 +171,11 @@ router.delete("/purge/:type/:id", (req, res) => {
   } else if (type === "run") {
     const run = runRepo.getByIdIncludeDeleted(id);
     if (!run || !run.deletedAt) {
+      return res.status(404).json({ error: "not found in recycle bin" });
+    }
+    // ACL-001: Verify the run's project belongs to the user's workspace.
+    const runProject = projectRepo.getByIdIncludeDeleted(run.projectId);
+    if (!runProject || runProject.workspaceId !== req.workspaceId) {
       return res.status(404).json({ error: "not found in recycle bin" });
     }
     runRepo.hardDeleteById(id);

--- a/backend/src/routes/runs.js
+++ b/backend/src/routes/runs.js
@@ -38,7 +38,7 @@ const router = Router();
 // ─── Crawl & Generate Tests ───────────────────────────────────────────────────
 
 router.post("/projects/:id/crawl", expensiveOpLimiter, async (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "not found" });
   const existingRun = runRepo.findActiveByProjectId(project.id);
   if (existingRun) {
@@ -99,7 +99,7 @@ router.post("/projects/:id/crawl", expensiveOpLimiter, async (req, res) => {
 // ─── Run Tests ────────────────────────────────────────────────────────────────
 
 router.post("/projects/:id/run", expensiveOpLimiter, async (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "not found" });
   const existingRun = runRepo.findActiveByProjectId(project.id);
   if (existingRun) {
@@ -173,6 +173,9 @@ router.get("/projects/:id/runs", (req, res) => {
 router.get("/runs/:runId", (req, res) => {
   const run = runRepo.getById(req.params.runId);
   if (!run) return res.status(404).json({ error: "not found" });
+  // Verify the run's project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(run.projectId, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
   res.json(signRunArtifacts(run));
 });
 
@@ -181,6 +184,9 @@ router.get("/runs/:runId", (req, res) => {
 router.post("/runs/:runId/abort", (req, res) => {
   const run = runRepo.getById(req.params.runId);
   if (!run) return res.status(404).json({ error: "not found" });
+  // Verify the run's project belongs to the user's workspace (ACL-001)
+  const ownerProject = projectRepo.getByIdInWorkspace(run.projectId, req.workspaceId);
+  if (!ownerProject) return res.status(404).json({ error: "not found" });
   if (run.status !== "running") {
     return res.status(409).json({ error: "Run is not in progress" });
   }
@@ -264,7 +270,7 @@ router.post("/runs/:runId/abort", (req, res) => {
  * List all trigger tokens for a project (hashes never returned).
  */
 router.get("/projects/:id/trigger-tokens", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "not found" });
   res.json(webhookTokenRepo.getByProjectId(project.id));
 });
@@ -278,7 +284,7 @@ router.get("/projects/:id/trigger-tokens", (req, res) => {
  * Response `201`: `{ id, token, label, createdAt }`
  */
 router.post("/projects/:id/trigger-tokens", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "not found" });
 
   const label = typeof req.body?.label === "string"
@@ -310,7 +316,7 @@ router.post("/projects/:id/trigger-tokens", (req, res) => {
  * Revoke (permanently delete) a trigger token.
  */
 router.delete("/projects/:id/trigger-tokens/:tid", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "not found" });
 
   // Verify the token belongs to this project before deleting (prevent

--- a/backend/src/routes/runs.js
+++ b/backend/src/routes/runs.js
@@ -161,6 +161,10 @@ router.post("/projects/:id/run", expensiveOpLimiter, async (req, res) => {
 // ─── Run listing ──────────────────────────────────────────────────────────────
 
 router.get("/projects/:id/runs", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
+
   const { page, pageSize } = req.query;
   if (page !== undefined || pageSize !== undefined) {
     const result = runRepo.getByProjectIdPaged(req.params.id, page, pageSize);

--- a/backend/src/routes/tests.js
+++ b/backend/src/routes/tests.js
@@ -69,6 +69,9 @@ router.get("/tests", (req, res) => {
 router.get("/tests/:testId", (req, res) => {
   const test = testRepo.getById(req.params.testId);
   if (!test) return res.status(404).json({ error: "not found" });
+  // Verify the test's project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(test.projectId, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
   res.json(test);
 });
 
@@ -79,6 +82,9 @@ router.patch("/tests/:testId", async (req, res) => {
 
   const test = testRepo.getById(req.params.testId);
   if (!test) return res.status(404).json({ error: "not found" });
+  // Verify the test's project belongs to the user's workspace (ACL-001)
+  const ownerProject = projectRepo.getByIdInWorkspace(test.projectId, req.workspaceId);
+  if (!ownerProject) return res.status(404).json({ error: "not found" });
 
   const { steps, name, description, priority, regenerateCode, previewCode, playwrightCode, linkedIssueKey, tags } = req.body;
 
@@ -295,7 +301,7 @@ router.post("/projects/:id/tests", (req, res) => {
   const validationErr = validateTestPayload(req.body);
   if (validationErr) return res.status(400).json({ error: validationErr });
 
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "project not found" });
 
   const { name, description, steps, playwrightCode, priority, type } = req.body;
@@ -460,7 +466,7 @@ router.post("/tests/:testId/run", expensiveOpLimiter, async (req, res) => {
   const test = testRepo.getById(req.params.testId);
   if (!test) return res.status(404).json({ error: "test not found" });
 
-  const project = projectRepo.getById(test.projectId);
+  const project = projectRepo.getByIdInWorkspace(test.projectId, req.workspaceId);
   if (!project) return res.status(404).json({ error: "project not found" });
 
   const runId = generateRunId();

--- a/backend/src/routes/tests.js
+++ b/backend/src/routes/tests.js
@@ -47,6 +47,10 @@ const router = Router();
 // ─── Test CRUD ────────────────────────────────────────────────────────────────
 
 router.get("/projects/:id/tests", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "project not found" });
+
   const { page, pageSize, reviewStatus, category, search } = req.query;
   if (page !== undefined || pageSize !== undefined) {
     const filters = {};
@@ -343,10 +347,12 @@ router.post("/projects/:id/tests", (req, res) => {
 });
 
 router.delete("/projects/:id/tests/:testId", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
   const test = testRepo.getById(req.params.testId);
   if (!test || test.projectId !== req.params.id)
     return res.status(404).json({ error: "not found" });
-  const project = projectRepo.getById(req.params.id);
   logActivity({ ...actor(req),
     type: "test.delete", projectId: req.params.id, projectName: project?.name || null,
     testId: req.params.testId, testName: test.name,
@@ -359,7 +365,7 @@ router.delete("/projects/:id/tests/:testId", (req, res) => {
 // ─── AI-powered test generation (pipeline-based) ──────────────────────────────
 
 router.post("/projects/:id/tests/generate", aiGenerationLimiter, async (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "project not found" });
 
   const { name, description, dialsConfig } = req.body;
@@ -513,14 +519,16 @@ router.post("/tests/:testId/run", expensiveOpLimiter, async (req, res) => {
 // ─── Test Review: Approve / Reject / Restore / Bulk ──────────────────────────
 
 router.patch("/projects/:id/tests/:testId/approve", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
   const test = testRepo.getById(req.params.testId);
   if (!test || test.projectId !== req.params.id)
     return res.status(404).json({ error: "not found" });
   const reviewedAt = new Date().toISOString();
   testRepo.update(test.id, { reviewStatus: "approved", reviewedAt });
-  const project = projectRepo.getById(req.params.id);
   logActivity({ ...actor(req),
-    type: "test.approve", projectId: req.params.id, projectName: project?.name || null,
+    type: "test.approve", projectId: req.params.id, projectName: project.name,
     testId: test.id, testName: test.name,
     detail: `Test approved — "${test.name}"`,
   });
@@ -528,14 +536,16 @@ router.patch("/projects/:id/tests/:testId/approve", (req, res) => {
 });
 
 router.patch("/projects/:id/tests/:testId/reject", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
   const test = testRepo.getById(req.params.testId);
   if (!test || test.projectId !== req.params.id)
     return res.status(404).json({ error: "not found" });
   const reviewedAt = new Date().toISOString();
   testRepo.update(test.id, { reviewStatus: "rejected", reviewedAt });
-  const project = projectRepo.getById(req.params.id);
   logActivity({ ...actor(req),
-    type: "test.reject", projectId: req.params.id, projectName: project?.name || null,
+    type: "test.reject", projectId: req.params.id, projectName: project.name,
     testId: test.id, testName: test.name,
     detail: `Test rejected — "${test.name}"`,
   });
@@ -543,13 +553,15 @@ router.patch("/projects/:id/tests/:testId/reject", (req, res) => {
 });
 
 router.patch("/projects/:id/tests/:testId/restore", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
   const test = testRepo.getById(req.params.testId);
   if (!test || test.projectId !== req.params.id)
     return res.status(404).json({ error: "not found" });
   testRepo.update(test.id, { reviewStatus: "draft", reviewedAt: null });
-  const project = projectRepo.getById(req.params.id);
   logActivity({ ...actor(req),
-    type: "test.restore", projectId: req.params.id, projectName: project?.name || null,
+    type: "test.restore", projectId: req.params.id, projectName: project.name,
     testId: test.id, testName: test.name,
     detail: `Test restored to draft — "${test.name}"`,
   });
@@ -558,6 +570,10 @@ router.patch("/projects/:id/tests/:testId/restore", (req, res) => {
 
 // NOTE: bulk must be declared BEFORE :testId wildcard routes to avoid conflict
 router.post("/projects/:id/tests/bulk", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "project not found" });
+
   const validationErr = validateBulkAction(req.body);
   if (validationErr) return res.status(400).json({ error: validationErr });
 
@@ -573,9 +589,8 @@ router.post("/projects/:id/tests/bulk", (req, res) => {
       }
     });
     if (deleted.length) {
-      const project = projectRepo.getById(req.params.id);
       logActivity({ ...actor(req),
-        type: "test.bulk_delete", projectId: req.params.id, projectName: project?.name || null,
+        type: "test.bulk_delete", projectId: req.params.id, projectName: project.name,
         detail: `Bulk delete — ${deleted.length} test${deleted.length !== 1 ? "s" : ""} moved to recycle bin`,
       });
     }
@@ -587,16 +602,15 @@ router.post("/projects/:id/tests/bulk", (req, res) => {
   const updated = testRepo.bulkUpdateReviewStatus(testIds, req.params.id, statusMap[action], reviewedAt);
 
   if (updated.length) {
-    const project = projectRepo.getById(req.params.id);
     for (const test of updated) {
       logActivity({ ...actor(req),
-        type: `test.${action}`, projectId: req.params.id, projectName: project?.name || null,
+        type: `test.${action}`, projectId: req.params.id, projectName: project.name,
         testId: test.id, testName: test.name,
         detail: `Test ${action === "approve" ? "approved" : action === "reject" ? "rejected" : "restored to draft"} (bulk) — "${test.name}"`,
       });
     }
     logActivity({ ...actor(req),
-      type: `test.bulk_${action}`, projectId: req.params.id, projectName: project?.name || null,
+      type: `test.bulk_${action}`, projectId: req.params.id, projectName: project.name,
       detail: `Bulk ${action} — ${updated.length} test${updated.length !== 1 ? "s" : ""}`,
     });
   }
@@ -606,6 +620,9 @@ router.post("/projects/:id/tests/bulk", (req, res) => {
 // ─── Test counts (lightweight — no row data, just per-status totals) ──────────
 
 router.get("/projects/:id/tests/counts", (req, res) => {
+  // Verify the project belongs to the user's workspace (ACL-001)
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "project not found" });
   const counts = testRepo.countByReviewStatus(req.params.id);
   res.json({ ...counts, total: counts.draft + counts.approved + counts.rejected });
 });
@@ -614,7 +631,7 @@ router.get("/projects/:id/tests/counts", (req, res) => {
 
 // GET /api/projects/:id/tests/export/zephyr — Zephyr Scale CSV for test management import
 router.get("/projects/:id/tests/export/zephyr", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "project not found" });
 
   const tests = testRepo.getByProjectId(req.params.id);
@@ -629,7 +646,7 @@ router.get("/projects/:id/tests/export/zephyr", (req, res) => {
 
 // GET /api/projects/:id/tests/export/testrail — TestRail CSV for bulk import
 router.get("/projects/:id/tests/export/testrail", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "project not found" });
 
   const tests = testRepo.getByProjectId(req.params.id);
@@ -644,7 +661,7 @@ router.get("/projects/:id/tests/export/testrail", (req, res) => {
 
 // GET /api/projects/:id/tests/traceability — traceability matrix (requirement → test → result)
 router.get("/projects/:id/tests/traceability", (req, res) => {
-  const project = projectRepo.getById(req.params.id);
+  const project = projectRepo.getByIdInWorkspace(req.params.id, req.workspaceId);
   if (!project) return res.status(404).json({ error: "project not found" });
 
   const tests = testRepo.getByProjectId(req.params.id);

--- a/backend/src/routes/tests.js
+++ b/backend/src/routes/tests.js
@@ -63,11 +63,15 @@ router.get("/projects/:id/tests", (req, res) => {
 });
 
 router.get("/tests", (req, res) => {
+  // Scope to the user's workspace by fetching workspace project IDs (ACL-001)
+  const wsProjects = projectRepo.getAll(req.workspaceId);
+  const projectIds = wsProjects.map(p => p.id);
+
   const { page, pageSize } = req.query;
   if (page !== undefined || pageSize !== undefined) {
-    return res.json(testRepo.getAllPaged(page, pageSize));
+    return res.json(testRepo.getAllPagedByProjectIds(projectIds, page, pageSize));
   }
-  res.json(testRepo.getAll());
+  res.json(testRepo.getAllByProjectIds(projectIds));
 });
 
 router.get("/tests/:testId", (req, res) => {

--- a/backend/src/routes/workspaces.js
+++ b/backend/src/routes/workspaces.js
@@ -1,0 +1,155 @@
+/**
+ * @module routes/workspaces
+ * @description Workspace and member management routes (ACL-001, ACL-002).
+ *
+ * ### Endpoints
+ * | Method | Path                                    | Description                   | Min Role |
+ * |--------|-----------------------------------------|-------------------------------|----------|
+ * | GET    | `/api/workspaces/current`               | Get current workspace info    | viewer   |
+ * | PATCH  | `/api/workspaces/current`               | Update workspace name/slug    | admin    |
+ * | GET    | `/api/workspaces/current/members`       | List workspace members        | viewer   |
+ * | POST   | `/api/workspaces/current/members`       | Invite a member               | admin    |
+ * | PATCH  | `/api/workspaces/current/members/:userId` | Update member role          | admin    |
+ * | DELETE | `/api/workspaces/current/members/:userId` | Remove a member             | admin    |
+ */
+
+import { Router } from "express";
+import * as workspaceRepo from "../database/repositories/workspaceRepo.js";
+import * as userRepo from "../database/repositories/userRepo.js";
+import { requireRole, VALID_ROLES } from "../middleware/requireRole.js";
+
+const router = Router();
+
+// ─── Current workspace info ───────────────────────────────────────────────────
+
+/**
+ * Get the current workspace details.
+ * @route GET /api/workspaces/current
+ */
+router.get("/current", (req, res) => {
+  const ws = workspaceRepo.getById(req.workspaceId);
+  if (!ws) return res.status(404).json({ error: "Workspace not found." });
+  return res.json(ws);
+});
+
+/**
+ * Update the current workspace (name, slug).
+ * @route PATCH /api/workspaces/current
+ */
+router.patch("/current", requireRole("admin"), (req, res) => {
+  const { name, slug } = req.body;
+  const updates = {};
+  if (name && typeof name === "string") updates.name = name.trim().slice(0, 100);
+  if (slug && typeof slug === "string") {
+    const cleanSlug = slug.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-|-$/g, "").slice(0, 50);
+    if (!cleanSlug) return res.status(400).json({ error: "Invalid slug." });
+    // Check uniqueness
+    const existing = workspaceRepo.getBySlug(cleanSlug);
+    if (existing && existing.id !== req.workspaceId) {
+      return res.status(409).json({ error: "This slug is already taken." });
+    }
+    updates.slug = cleanSlug;
+  }
+  if (Object.keys(updates).length === 0) {
+    return res.status(400).json({ error: "No valid fields to update." });
+  }
+  workspaceRepo.update(req.workspaceId, updates);
+  const ws = workspaceRepo.getById(req.workspaceId);
+  return res.json(ws);
+});
+
+// ─── Member management ────────────────────────────────────────────────────────
+
+/**
+ * List all members of the current workspace.
+ * @route GET /api/workspaces/current/members
+ */
+router.get("/current/members", (req, res) => {
+  const members = workspaceRepo.getMembers(req.workspaceId);
+  return res.json(members);
+});
+
+/**
+ * Invite a user to the current workspace by email.
+ * @route POST /api/workspaces/current/members
+ */
+router.post("/current/members", requireRole("admin"), (req, res) => {
+  const { email, role } = req.body;
+  if (!email || typeof email !== "string") {
+    return res.status(400).json({ error: "Email is required." });
+  }
+  const memberRole = role || "viewer";
+  if (!VALID_ROLES.has(memberRole)) {
+    return res.status(400).json({ error: `Invalid role. Must be one of: ${[...VALID_ROLES].join(", ")}` });
+  }
+
+  const user = userRepo.getByEmail(email.trim().toLowerCase());
+  if (!user) {
+    return res.status(404).json({ error: "No user found with that email. They must register first." });
+  }
+
+  // Check if already a member
+  const existing = workspaceRepo.getMembership(req.workspaceId, user.id);
+  if (existing) {
+    return res.status(409).json({ error: "User is already a member of this workspace." });
+  }
+
+  const membership = workspaceRepo.addMember(req.workspaceId, user.id, memberRole);
+  return res.status(201).json({
+    ...membership,
+    name: user.name,
+    email: user.email,
+    avatar: user.avatar || null,
+  });
+});
+
+/**
+ * Update a member's role.
+ * @route PATCH /api/workspaces/current/members/:userId
+ */
+router.patch("/current/members/:userId", requireRole("admin"), (req, res) => {
+  const { userId } = req.params;
+  const { role } = req.body;
+
+  if (!role || !VALID_ROLES.has(role)) {
+    return res.status(400).json({ error: `Invalid role. Must be one of: ${[...VALID_ROLES].join(", ")}` });
+  }
+
+  // Prevent demoting the last admin
+  if (role !== "admin") {
+    const members = workspaceRepo.getMembers(req.workspaceId);
+    const admins = members.filter(m => m.role === "admin");
+    if (admins.length === 1 && admins[0].userId === userId) {
+      return res.status(400).json({ error: "Cannot remove the last admin. Promote another member first." });
+    }
+  }
+
+  const updated = workspaceRepo.updateMemberRole(req.workspaceId, userId, role);
+  if (!updated) {
+    return res.status(404).json({ error: "Member not found in this workspace." });
+  }
+  return res.json({ userId, role, updated: true });
+});
+
+/**
+ * Remove a member from the workspace.
+ * @route DELETE /api/workspaces/current/members/:userId
+ */
+router.delete("/current/members/:userId", requireRole("admin"), (req, res) => {
+  const { userId } = req.params;
+
+  // Prevent removing yourself if you're the last admin
+  const members = workspaceRepo.getMembers(req.workspaceId);
+  const admins = members.filter(m => m.role === "admin");
+  if (admins.length === 1 && admins[0].userId === userId) {
+    return res.status(400).json({ error: "Cannot remove the last admin. Transfer ownership first." });
+  }
+
+  const removed = workspaceRepo.removeMember(req.workspaceId, userId);
+  if (!removed) {
+    return res.status(404).json({ error: "Member not found in this workspace." });
+  }
+  return res.json({ userId, removed: true });
+});
+
+export default router;

--- a/backend/src/utils/activityLogger.js
+++ b/backend/src/utils/activityLogger.js
@@ -28,9 +28,10 @@ import * as activityRepo from "../database/repositories/activityRepo.js";
  * @param {string}      [opts.status="completed"] - Activity status.
  * @param {string}      [opts.userId]    - ID of the user who triggered the action (from req.authUser.sub).
  * @param {string}      [opts.userName]  - Display name of the user (from req.authUser.name or email).
+ * @param {string}      [opts.workspaceId] - Workspace ID for multi-tenancy scoping (ACL-001).
  * @returns {Object}    The created activity record.
  */
-export function logActivity({ type, projectId, projectName, testId, testName, detail, status, userId, userName }) {
+export function logActivity({ type, projectId, projectName, testId, testName, detail, status, userId, userName, workspaceId }) {
   const id = generateActivityId();
   const activity = {
     id,
@@ -44,6 +45,7 @@ export function logActivity({ type, projectId, projectName, testId, testName, de
     createdAt: new Date().toISOString(),
     userId: userId || null,
     userName: userName || null,
+    workspaceId: workspaceId || null,
   };
   activityRepo.create(activity);
   return activity;

--- a/backend/src/utils/actor.js
+++ b/backend/src/utils/actor.js
@@ -6,11 +6,16 @@
  */
 
 /**
- * @param {Object} req - Express request with `authUser` set by requireAuth.
- * @returns {{ userId: string, userName: string } | {}}
+ * @param {Object} req - Express request with `authUser` set by requireAuth
+ *                        and `workspaceId` set by workspaceScope.
+ * @returns {{ userId: string, userName: string, workspaceId: string } | {}}
  */
 export function actor(req) {
   const u = req?.authUser;
   if (!u) return {};
-  return { userId: u.sub, userName: u.name || u.email || u.sub };
+  return {
+    userId: u.sub,
+    userName: u.name || u.email || u.sub,
+    workspaceId: req.workspaceId || null,
+  };
 }

--- a/backend/src/utils/idGenerator.js
+++ b/backend/src/utils/idGenerator.js
@@ -66,6 +66,22 @@ export function generateScheduleId() {
 }
 
 /**
+ * generateWorkspaceId() → "WS-1", "WS-2", …
+ * Used for multi-tenancy workspaces (ACL-001).
+ */
+export function generateWorkspaceId() {
+  return `WS-${counterRepo.next("workspace")}`;
+}
+
+/**
+ * generateWorkspaceMemberId() → "WM-1", "WM-2", …
+ * Used for workspace membership records (ACL-002).
+ */
+export function generateWorkspaceMemberId() {
+  return `WM-${counterRepo.next("workspace_member")}`;
+}
+
+/**
  * No-op — counters are now managed by the SQLite `counters` table.
  * Kept for backward compatibility so existing callers don't break.
  * The migration script (database/migrate.js) seeds the counters table

--- a/backend/tests/api-flow.test.js
+++ b/backend/tests/api-flow.test.js
@@ -18,16 +18,16 @@ import * as activityRepo from "../src/database/repositories/activityRepo.js";
 import { createTestContext } from "./helpers/test-base.js";
 
 const t = createTestContext();
-const { app, req } = t;
+const { app, req, workspaceScope } = t;
 
 let mounted = false;
 function mountRoutesOnce() {
   if (mounted) return;
   app.use("/api/auth", authRouter);
-  app.use("/api/projects", requireAuth, projectsRouter);
-  app.use("/api", requireAuth, testsRouter);
-  app.use("/api", requireAuth, runsRouter);
-  app.use("/api", requireAuth, sseRouter);
+  app.use("/api/projects", requireAuth, workspaceScope, projectsRouter);
+  app.use("/api", requireAuth, workspaceScope, testsRouter);
+  app.use("/api", requireAuth, workspaceScope, runsRouter);
+  app.use("/api", requireAuth, workspaceScope, sseRouter);
   mounted = true;
 }
 

--- a/backend/tests/helpers/test-base.js
+++ b/backend/tests/helpers/test-base.js
@@ -38,6 +38,7 @@
 import assert from "node:assert/strict";
 import { app } from "../../src/middleware/appSetup.js";
 import { getDatabase } from "../../src/database/sqlite.js";
+import { workspaceScope } from "../../src/middleware/workspaceScope.js";
 
 // ─── Cookie helpers ───────────────────────────────────────────────────────────
 

--- a/backend/tests/helpers/test-base.js
+++ b/backend/tests/helpers/test-base.js
@@ -119,6 +119,8 @@ const RESET_TABLES = [
   "tests",
   "oauth_ids",
   "projects",
+  "workspace_members",
+  "workspaces",
   "users",
 ];
 
@@ -325,6 +327,7 @@ export function createTestContext() {
   return {
     app,
     getDatabase,
+    workspaceScope,
     req,
     extractCookie: ec,
     parseCookies,

--- a/backend/tests/recycle-bin.test.js
+++ b/backend/tests/recycle-bin.test.js
@@ -14,7 +14,7 @@ import * as testRepo from "../src/database/repositories/testRepo.js";
 import { createTestContext } from "./helpers/test-base.js";
 
 const t = createTestContext();
-const { app, req, getDatabase } = t;
+const { app, req, getDatabase, workspaceScope } = t;
 const { test, summary } = t.createTestRunner();
 
 // ─── Mount routes once ────────────────────────────────────────────────────────
@@ -23,9 +23,9 @@ let mounted = false;
 function mountOnce() {
   if (mounted) return;
   app.use("/api/auth", authRouter);
-  app.use("/api/projects", requireAuth, projectsRouter);
-  app.use("/api", requireAuth, testsRouter);
-  app.use("/api", requireAuth, recycleBinRouter);
+  app.use("/api/projects", requireAuth, workspaceScope, projectsRouter);
+  app.use("/api", requireAuth, workspaceScope, testsRouter);
+  app.use("/api", requireAuth, workspaceScope, recycleBinRouter);
   mounted = true;
 }
 
@@ -40,11 +40,12 @@ async function main() {
   const base = `http://127.0.0.1:${port}`;
 
   // Register + login using shared helper
-  const { token } = await t.registerAndLogin(base, {
+  const { token, payload } = await t.registerAndLogin(base, {
     name: "RB Test",
     email: "rb-test@recycle-bin-test.com",
     password: "RbTest1234!",
   });
+  const wsId = payload.workspaceId;
 
   // ── Create shared test data directly via repos (fast, no HTTP overhead) ──
   const prbId = "PRJ-RB-001";
@@ -54,7 +55,7 @@ async function main() {
 
   await test("returns empty recycle bin when nothing is deleted", async () => {
     // Seed a live project
-    projectRepo.create({ id: prbId, name: "RB Project", url: "https://rb.test", createdAt: new Date().toISOString(), status: "idle" });
+    projectRepo.create({ id: prbId, name: "RB Project", url: "https://rb.test", createdAt: new Date().toISOString(), status: "idle", workspaceId: wsId });
     testRepo.create({ id: trbId, projectId: prbId, name: "RB Test", description: "", steps: [], tags: [], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), reviewStatus: "draft", priority: "medium", codeVersion: 0, isJourneyTest: false, assertionEnhanced: false });
 
     const { res, json } = await req(base, "/api/recycle-bin", { token });
@@ -137,7 +138,7 @@ async function main() {
   await test("deleting a project cascades soft-delete to its tests", async () => {
     const cid = "PRJ-RB-002";
     const ctid = "TC-RB-003";
-    projectRepo.create({ id: cid, name: "Cascade Project", url: "https://cascade.test", createdAt: new Date().toISOString(), status: "idle" });
+    projectRepo.create({ id: cid, name: "Cascade Project", url: "https://cascade.test", createdAt: new Date().toISOString(), status: "idle", workspaceId: wsId });
     testRepo.create({ id: ctid, projectId: cid, name: "Cascade Test", description: "", steps: [], tags: [], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), reviewStatus: "draft", priority: "medium", codeVersion: 0, isJourneyTest: false, assertionEnhanced: false });
 
     const { res } = await req(base, `/api/projects/${cid}`, { method: "DELETE", token });
@@ -156,7 +157,7 @@ async function main() {
     const scid = "PRJ-RB-003";
     const stid1 = "TC-RB-010";
     const stid2 = "TC-RB-011";
-    projectRepo.create({ id: scid, name: "Scoped Project", url: "https://scoped.test", createdAt: new Date().toISOString(), status: "idle" });
+    projectRepo.create({ id: scid, name: "Scoped Project", url: "https://scoped.test", createdAt: new Date().toISOString(), status: "idle", workspaceId: wsId });
     testRepo.create({ id: stid1, projectId: scid, name: "Individually Deleted", description: "", steps: [], tags: [], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), reviewStatus: "draft", priority: "medium", codeVersion: 0, isJourneyTest: false, assertionEnhanced: false });
     testRepo.create({ id: stid2, projectId: scid, name: "Cascade Deleted", description: "", steps: [], tags: [], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), reviewStatus: "draft", priority: "medium", codeVersion: 0, isJourneyTest: false, assertionEnhanced: false });
 

--- a/backend/tests/scheduler.test.js
+++ b/backend/tests/scheduler.test.js
@@ -322,8 +322,10 @@ if (dbAvailable) {
   const projectsRouter = (await import("../src/routes/projects.js")).default;
   const authRouter = (await import("../src/routes/auth.js")).default;
   const { requireAuth } = await import("../src/routes/auth.js");
+  const { workspaceScope } = await import("../src/middleware/workspaceScope.js");
+  const { ensureDefaultWorkspaces } = await import("../src/database/repositories/workspaceRepo.js");
   app.use("/api/auth", authRouter);
-  app.use("/api/projects", requireAuth, projectsRouter);
+  app.use("/api/projects", requireAuth, workspaceScope, projectsRouter);
 
   const server = createServer(app);
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));

--- a/backend/tests/trigger-api.test.js
+++ b/backend/tests/trigger-api.test.js
@@ -15,6 +15,7 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { app } from "../src/middleware/appSetup.js";
 import authRouter, { requireAuth } from "../src/routes/auth.js";
+import { workspaceScope } from "../src/middleware/workspaceScope.js";
 import projectsRouter from "../src/routes/projects.js";
 import testsRouter from "../src/routes/tests.js";
 import runsRouter from "../src/routes/runs.js";
@@ -26,9 +27,9 @@ function mountRoutesOnce() {
   if (mounted) return;
   app.use("/api/auth", authRouter);
   app.use("/api", triggerRouter);
-  app.use("/api/projects", requireAuth, projectsRouter);
-  app.use("/api", requireAuth, testsRouter);
-  app.use("/api", requireAuth, runsRouter);
+  app.use("/api/projects", requireAuth, workspaceScope, projectsRouter);
+  app.use("/api", requireAuth, workspaceScope, testsRouter);
+  app.use("/api", requireAuth, workspaceScope, runsRouter);
   mounted = true;
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **API**: Multi-tenancy workspaces — all entities (projects, tests, runs, activities) are scoped to workspaces; workspace management endpoints at `/api/workspaces/*` (ACL-001) (#88)
+- **API**: Role-based access control — `admin`/`qa_lead`/`viewer` roles enforced via `requireRole` middleware; role hierarchy admin > qa_lead > viewer (ACL-002) (#88)
+- **DB**: Migration 004 — `workspaces` and `workspace_members` tables; `workspaceId` foreign key on projects, tests, runs, activities (ACL-001) (#88)
+- **Auth**: JWT now includes `workspaceId` hint; workspace role resolved from DB on every request for immediate permission changes (ACL-001, ACL-002) (#88)
+- **Frontend**: `ProtectedRoute` supports `requiredRole` prop for role-gated pages; `AuthContext` exposes `workspaceId`, `workspaceName`, `workspaceRole` (ACL-002) (#88)
+
 ## [1.5.0] — 2026-04-17
 
 ### Added

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -63,7 +63,7 @@ export default function App() {
                 <Route path="/projects/:id" element={<ProjectDetail />} />
                 <Route path="/runs/:runId" element={<RunDetail />} />
                 <Route path="/tests/:testId" element={<TestDetail />} />
-                <Route path="/settings" element={<Settings />} />
+                <Route path="/settings" element={<ProtectedRoute requiredRole="admin"><Settings /></ProtectedRoute>} />
                 <Route path="/reports" element={<Reports />} />
                 <Route path="/runs" element={<Runs />} />
                 <Route path="/system" element={<Systems />} />

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -349,6 +349,20 @@ export const api = {
    */
   resendVerification: (email) => req("POST", "/auth/resend-verification", { email }),
 
+  // ── Workspace & Members (ACL-001, ACL-002) ───────────────────────────────────
+  /** @returns {Promise<Object>} Current workspace details. */
+  getWorkspace:      ()              => req("GET",    "/workspaces/current"),
+  /** @param {Object} data - `{ name?, slug? }` */
+  updateWorkspace:   (data)          => req("PATCH",  "/workspaces/current", data),
+  /** @returns {Promise<Array>} List of workspace members with roles. */
+  getMembers:        ()              => req("GET",    "/workspaces/current/members"),
+  /** @param {Object} data - `{ email, role? }` */
+  inviteMember:      (data)          => req("POST",   "/workspaces/current/members", data),
+  /** @param {string} userId @param {string} role */
+  updateMemberRole:  (userId, role)  => req("PATCH",  `/workspaces/current/members/${userId}`, { role }),
+  /** @param {string} userId */
+  removeMember:      (userId)        => req("DELETE", `/workspaces/current/members/${userId}`),
+
   // ── System info & data management ───────────────────────────────────────────
   /** @returns {Promise<Object>} Uptime, Node/Playwright versions, memory, DB counts. */
   getSystemInfo:   () => req("GET",    "/system"),

--- a/frontend/src/components/layout/ProtectedRoute.jsx
+++ b/frontend/src/components/layout/ProtectedRoute.jsx
@@ -1,10 +1,14 @@
 /**
  * @module components/ProtectedRoute
- * @description Route guard that requires authentication.
+ * @description Route guard that requires authentication and optional role check.
  *
  * Wraps routes that require a signed-in user. If the user is not authenticated,
  * they are redirected to `/login` with the current location saved in state
  * so they can be sent back after sign-in.
+ *
+ * ### Role-based guarding (ACL-002)
+ * Pass `requiredRole` to restrict access by workspace role.
+ * Role hierarchy: `admin > qa_lead > viewer`.
  *
  * While the auth token is being validated (e.g. on initial page load), a
  * lightweight skeleton placeholder is shown instead of a blank screen to
@@ -12,16 +16,36 @@
  *
  * @param {Object} props
  * @param {React.ReactNode} props.children - Protected child routes/components.
+ * @param {string} [props.requiredRole] - Minimum workspace role ('admin' | 'qa_lead' | 'viewer').
  * @returns {React.ReactElement}
  *
  * @example
  * <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
  *   <Route path="/dashboard" element={<Dashboard />} />
  * </Route>
+ *
+ * // Role-gated route:
+ * <Route element={<ProtectedRoute requiredRole="admin"><Settings /></ProtectedRoute>} />
  */
 
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext.jsx";
+
+/** Role hierarchy weights — higher = more privileged. */
+const ROLE_WEIGHT = { admin: 30, qa_lead: 20, viewer: 10 };
+
+/**
+ * Check if the user's workspace role meets the minimum required role.
+ * @param {string|null} userRole
+ * @param {string} requiredRole
+ * @returns {boolean}
+ */
+function hasMinimumRole(userRole, requiredRole) {
+  if (!requiredRole) return true;
+  const userW = ROLE_WEIGHT[userRole] || 0;
+  const reqW = ROLE_WEIGHT[requiredRole] || 0;
+  return userW >= reqW;
+}
 
 function AuthLoadingSkeleton() {
   return (
@@ -60,7 +84,7 @@ function AuthLoadingSkeleton() {
   );
 }
 
-export default function ProtectedRoute({ children }) {
+export default function ProtectedRoute({ children, requiredRole }) {
   const { user, loading } = useAuth();
   const location = useLocation();
 
@@ -71,5 +95,35 @@ export default function ProtectedRoute({ children }) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
+  // ACL-002: Role-based access check
+  if (requiredRole && !hasMinimumRole(user.workspaceRole, requiredRole)) {
+    return (
+      <div style={{ padding: "80px 0", textAlign: "center", color: "var(--text2)" }}>
+        <div style={{ fontSize: "3rem", marginBottom: 16 }}>403</div>
+        <div style={{ fontWeight: 700, fontSize: "1.2rem", color: "var(--text)", marginBottom: 8 }}>
+          Access Denied
+        </div>
+        <div style={{ fontSize: "0.875rem", marginBottom: 24 }}>
+          This page requires <strong>{requiredRole}</strong> permissions.
+          Your current role is <strong>{user.workspaceRole || "viewer"}</strong>.
+        </div>
+      </div>
+    );
+  }
+
   return children;
+}
+
+/**
+ * Check if a user has the minimum required workspace role.
+ * Exported for use in components that need to conditionally render
+ * UI elements based on role (e.g. hide delete buttons for viewers).
+ *
+ * @param {Object|null} user — The user object from useAuth().
+ * @param {string} role — Minimum role required.
+ * @returns {boolean}
+ */
+export function userHasRole(user, role) {
+  if (!user) return false;
+  return hasMinimumRole(user.workspaceRole, role);
 }

--- a/frontend/src/components/layout/ProtectedRoute.jsx
+++ b/frontend/src/components/layout/ProtectedRoute.jsx
@@ -30,22 +30,7 @@
 
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext.jsx";
-
-/** Role hierarchy weights — higher = more privileged. */
-const ROLE_WEIGHT = { admin: 30, qa_lead: 20, viewer: 10 };
-
-/**
- * Check if the user's workspace role meets the minimum required role.
- * @param {string|null} userRole
- * @param {string} requiredRole
- * @returns {boolean}
- */
-function hasMinimumRole(userRole, requiredRole) {
-  if (!requiredRole) return true;
-  const userW = ROLE_WEIGHT[userRole] || 0;
-  const reqW = ROLE_WEIGHT[requiredRole] || 0;
-  return userW >= reqW;
-}
+import { hasMinimumRole } from "../../utils/roles.js";
 
 function AuthLoadingSkeleton() {
   return (
@@ -114,16 +99,5 @@ export default function ProtectedRoute({ children, requiredRole }) {
   return children;
 }
 
-/**
- * Check if a user has the minimum required workspace role.
- * Exported for use in components that need to conditionally render
- * UI elements based on role (e.g. hide delete buttons for viewers).
- *
- * @param {Object|null} user — The user object from useAuth().
- * @param {string} role — Minimum role required.
- * @returns {boolean}
- */
-export function userHasRole(user, role) {
-  if (!user) return false;
-  return hasMinimumRole(user.workspaceRole, role);
-}
+// Re-export for backward compatibility — prefer importing from utils/roles.js directly.
+export { userHasRole } from "../../utils/roles.js";

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import { LayoutDashboard, FlaskConical, FolderOpen, BarChart2, Briefcase, Layers, Zap, Settings, BookOpen, ExternalLink, MessageSquare } from "lucide-react";
 import AppLogo from "./AppLogo.jsx";
+import { useAuth } from "../../context/AuthContext.jsx";
+import { userHasRole } from "../../utils/roles.js";
 
 const NAV = [
   { to: "/dashboard", icon: LayoutDashboard, label: "Dashboard", tour: "tour-dashboard" },
@@ -15,6 +17,9 @@ const NAV = [
 ];
 
 export default function Sidebar({ open }) {
+  const { user } = useAuth();
+  const isAdmin = userHasRole(user, "admin");
+
   return (
     <aside className={open ? "sidebar-open" : ""} style={{
       width: 192, background: "var(--surface)", borderRight: "1px solid var(--border)",
@@ -26,11 +31,11 @@ export default function Sidebar({ open }) {
         <AppLogo size={30} variant="full" />
       </div>
 
-      {/* Workspace — no interactive styling until feature exists (Fix #16) */}
+      {/* Workspace name from auth context (ACL-001) */}
       <div style={{ padding: "10px 12px", borderBottom: "1px solid var(--border)" }}>
         <div style={{ padding: "6px 8px", borderRadius: "var(--radius)" }}>
-          <div style={{ fontSize: "0.78rem", fontWeight: 600, color: "var(--text)" }}>My Workspace</div>
-          <div style={{ fontSize: "0.7rem", color: "var(--text3)" }}>Personal</div>
+          <div style={{ fontSize: "0.78rem", fontWeight: 600, color: "var(--text)" }}>{user?.workspaceName || "My Workspace"}</div>
+          <div style={{ fontSize: "0.7rem", color: "var(--text3)", textTransform: "capitalize" }}>{user?.workspaceRole || "Personal"}</div>
         </div>
       </div>
 
@@ -51,8 +56,9 @@ export default function Sidebar({ open }) {
         ))}
       </nav>
 
-      {/* Settings + Docs at bottom */}
+      {/* Settings (admin only) + Docs at bottom */}
       <div style={{ padding: "10px 8px", borderTop: "1px solid var(--border)" }}>
+        {isAdmin && (
         <NavLink to="/settings" className="nav-link" data-tour="tour-settings" style={({ isActive }) => ({
           display: "flex", alignItems: "center", gap: 9, padding: "7px 10px",
           borderRadius: "var(--radius)", fontWeight: isActive ? 600 : 400,
@@ -62,6 +68,7 @@ export default function Sidebar({ open }) {
         })}>
           <Settings size={16} />Settings
         </NavLink>
+        )}
         <a href={`${import.meta.env.BASE_URL}docs/`} target="_blank" rel="noopener noreferrer" style={{
           display: "flex", alignItems: "center", gap: 9, padding: "7px 10px",
           borderRadius: "var(--radius)", fontSize: "0.875rem", color: "var(--text2)",

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -65,7 +65,12 @@ function msUntilRefresh() {
 }
 
 function sanitiseUser(u) {
-  return { id: u.id, name: u.name, email: u.email, avatar: u.avatar || null, role: u.role || "user" };
+  return {
+    id: u.id, name: u.name, email: u.email, avatar: u.avatar || null, role: u.role || "user",
+    workspaceId: u.workspaceId || null,
+    workspaceName: u.workspaceName || null,
+    workspaceRole: u.workspaceRole || null,
+  };
 }
 
 // ─── Provider ─────────────────────────────────────────────────────────────────

--- a/frontend/src/pages/ProjectDetail.jsx
+++ b/frontend/src/pages/ProjectDetail.jsx
@@ -14,6 +14,8 @@ import { StatusBadge, ReviewBadge, ScenarioBadges } from "../components/shared/T
 import usePageTitle from "../hooks/usePageTitle.js";
 import useProjectRunMonitor from "../hooks/useProjectRunMonitor.js";
 import { useNotifications } from "../context/NotificationContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
+import { userHasRole } from "../utils/roles.js";
 import ActiveRunBanner from "../components/project/ActiveRunBanner.jsx";
 import RunToast from "../components/project/RunToast.jsx";
 import RunsTab from "../components/project/RunsTab.jsx";
@@ -69,6 +71,8 @@ export default function ProjectDetail() {
   const [traceability, setTraceability]     = useState(null);
   const [traceLoading, setTraceLoading]     = useState(false);
   const { addNotification } = useNotifications();
+  const { user: authUser } = useAuth();
+  const canEdit = userHasRole(authUser, "qa_lead");
 
   // ── Debounce search input → search state (300ms) ───────────────────────────
   useEffect(() => {
@@ -472,10 +476,12 @@ export default function ProjectDetail() {
                     onClick={() => bulkAction("reject")}>
                     <ThumbsDown size={12} /> Reject {bulkScope}
                   </button>
+                  {canEdit && (
                   <button className="btn btn-sm" style={{ background: "var(--red-bg)", color: "var(--red)", border: "1px solid #fca5a5" }}
                     onClick={requestBulkDelete}>
                     <Trash2 size={12} /> Delete {bulkScope}
                   </button>
+                  )}
                   {selected.size > 0 && (
                     <button className="btn btn-ghost btn-sm" onClick={() => setSelected(new Set())}>Clear selection</button>
                   )}
@@ -571,12 +577,14 @@ export default function ProjectDetail() {
                                     <RotateCcw size={11} /> Restore
                                   </button>
                                 )}
+                                {canEdit && (
                                 <button className="btn btn-ghost btn-xs" onClick={() => {
                                   if (!window.confirm(`Delete test "${t.name}"? This cannot be undone.`)) return;
                                   api.deleteTest(id, t.id).then(refresh).catch(err => showToast(err.message, "error"));
                                 }}>
                                   <Trash2 size={11} />
                                 </button>
+                                )}
                               </div>
                             </td>
                           </tr>

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -17,6 +17,8 @@ import PassRateBar from "../components/charts/PassRateBar";
 import DeleteProjectModal from "../components/shared/DeleteProjectModal.jsx";
 import { api } from "../api.js";
 import usePageTitle from "../hooks/usePageTitle.js";
+import { useAuth } from "../context/AuthContext.jsx";
+import { userHasRole } from "../utils/roles.js";
 
 function StatusDot({ status }) {
   const colors = {
@@ -39,6 +41,8 @@ export default function Projects() {
   const [search, setSearch] = useState("");
   const [deleteTarget, setDeleteTarget] = useState(null); // project to confirm-delete
   const navigate = useNavigate();
+  const { user } = useAuth();
+  const canDelete = userHasRole(user, "qa_lead");
 
   // Derive per-project stats from the shared hook data
   const projectStats = useMemo(() => {
@@ -225,6 +229,7 @@ export default function Projects() {
                   >
                     <FlaskConical size={13} /> Tests
                   </button>
+                  {canDelete && (
                   <button
                     className="btn btn-ghost btn-sm"
                     style={{ color: "var(--text3)" }}
@@ -233,6 +238,7 @@ export default function Projects() {
                   >
                     <Trash2 size={13} />
                   </button>
+                  )}
                   <ChevronRight size={16} color="var(--text3)" style={{ marginLeft: 4 }} />
                 </div>
               </div>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -5,11 +5,13 @@ import {
   RefreshCw, Trash2, Zap, Database, Server, Clock, Cpu,
   Activity, Shield, HardDrive, Info, Wifi, WifiOff, Terminal,
   Compass, RotateCcw, FolderOpen, FileText, Play, AlertCircle,
+  Users, UserPlus, Crown, ChevronDown,
 } from "lucide-react";
 import { api } from "../api.js";
 import { invalidateConfigCache } from "../components/layout/ProviderBadge.jsx";
 import { resetOnboarding, emitTourEvent } from "../hooks/useOnboarding.js";
 import usePageTitle from "../hooks/usePageTitle.js";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const PROVIDERS = [
   {
@@ -521,12 +523,227 @@ function fmtUptime(seconds) {
 
 const SETTINGS_TABS = [
   { key: "providers",   label: "AI Providers",  icon: <Zap size={14} /> },
+  { key: "members",     label: "Members",       icon: <Users size={14} /> },
   { key: "execution",   label: "Execution",     icon: <Cpu size={14} /> },
   { key: "data",        label: "Data",          icon: <Database size={14} /> },
   { key: "recycle-bin", label: "Recycle Bin",   icon: <Trash2 size={14} /> },
   { key: "system",      label: "System",        icon: <Server size={14} /> },
 ];
 
+
+// ── Members tab (ACL-002) ─────────────────────────────────────────────────────
+
+const ROLE_OPTIONS = [
+  { value: "admin",   label: "Admin",   desc: "Full access — manage members, settings, and all data" },
+  { value: "qa_lead", label: "QA Lead", desc: "Create, edit, run, and delete tests and projects" },
+  { value: "viewer",  label: "Viewer",  desc: "Read-only access to all data" },
+];
+
+function MembersTab() {
+  const { user } = useAuth();
+  const [members, setMembers]     = useState([]);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole]   = useState("viewer");
+  const [inviting, setInviting]   = useState(false);
+  const [inviteMsg, setInviteMsg] = useState(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.getMembers();
+      setMembers(data);
+    } catch (e) {
+      setError(e.message || "Failed to load members");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, []);
+
+  async function handleInvite(e) {
+    e.preventDefault();
+    if (!inviteEmail.trim()) return;
+    setInviting(true);
+    setInviteMsg(null);
+    try {
+      await api.inviteMember({ email: inviteEmail.trim().toLowerCase(), role: inviteRole });
+      setInviteEmail("");
+      setInviteRole("viewer");
+      setInviteMsg({ type: "ok", text: "Member invited successfully." });
+      await load();
+    } catch (err) {
+      setInviteMsg({ type: "err", text: err.message });
+    } finally {
+      setInviting(false);
+    }
+  }
+
+  async function handleRoleChange(userId, role) {
+    try {
+      await api.updateMemberRole(userId, role);
+      await load();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleRemove(userId, name) {
+    if (!window.confirm(`Remove ${name} from this workspace?`)) return;
+    try {
+      await api.removeMember(userId);
+      await load();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  if (loading) return (
+    <div className="text-sm text-muted" style={{ padding: "32px 0", textAlign: "center" }}>
+      Loading members…
+    </div>
+  );
+
+  return (
+    <div className="flex-col gap-lg">
+      <SectionTitle
+        icon={<Users size={16} color="var(--accent)" />}
+        title="Workspace Members"
+        sub={`${members.length} member${members.length !== 1 ? "s" : ""}`}
+      />
+
+      {error && (
+        <div className="card card-padded" style={{ borderColor: "var(--danger)", color: "var(--danger)", display: "flex", gap: 8, alignItems: "center" }}>
+          <AlertCircle size={15} /> {error}
+        </div>
+      )}
+
+      {/* Invite form */}
+      <form onSubmit={handleInvite} className="card card-padded" style={{ display: "flex", gap: 10, alignItems: "flex-end", flexWrap: "wrap" }}>
+        <div style={{ flex: "1 1 220px", minWidth: 180 }}>
+          <label style={{ display: "block", fontSize: "0.8rem", fontWeight: 600, marginBottom: 5, color: "var(--text2)" }}>
+            <UserPlus size={12} style={{ marginRight: 4, verticalAlign: "middle" }} />
+            Invite by email
+          </label>
+          <input
+            className="input"
+            type="email"
+            value={inviteEmail}
+            onChange={e => setInviteEmail(e.target.value)}
+            placeholder="colleague@company.com"
+            style={{ height: 36, fontSize: "0.85rem" }}
+            required
+          />
+        </div>
+        <div style={{ flex: "0 0 130px" }}>
+          <label style={{ display: "block", fontSize: "0.8rem", fontWeight: 600, marginBottom: 5, color: "var(--text2)" }}>
+            Role
+          </label>
+          <select
+            className="input"
+            value={inviteRole}
+            onChange={e => setInviteRole(e.target.value)}
+            style={{ height: 36, fontSize: "0.85rem" }}
+          >
+            {ROLE_OPTIONS.map(r => (
+              <option key={r.value} value={r.value}>{r.label}</option>
+            ))}
+          </select>
+        </div>
+        <button className="btn btn-primary btn-sm" type="submit" disabled={inviting || !inviteEmail.trim()} style={{ height: 36 }}>
+          {inviting ? <RefreshCw size={13} className="spin" /> : <UserPlus size={13} />}
+          Invite
+        </button>
+      </form>
+      {inviteMsg && (
+        <div className={inviteMsg.type === "ok" ? "st-status-ok" : "st-status-err"}>
+          {inviteMsg.type === "ok" ? <Check size={12} /> : <AlertCircle size={12} />} {inviteMsg.text}
+        </div>
+      )}
+
+      {/* Member list */}
+      <div className="flex-col gap-xs">
+        {members.map(m => {
+          const isCurrentUser = m.userId === user?.id;
+          return (
+            <div key={m.userId} className="card" style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 16px" }}>
+              {/* Avatar / initial */}
+              <div style={{
+                width: 34, height: 34, borderRadius: "50%", flexShrink: 0,
+                background: "var(--bg3)", display: "flex", alignItems: "center", justifyContent: "center",
+                fontSize: "0.82rem", fontWeight: 700, color: "var(--text2)",
+                overflow: "hidden",
+              }}>
+                {m.avatar
+                  ? <img src={m.avatar} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                  : (m.name || m.email || "?").charAt(0).toUpperCase()}
+              </div>
+
+              {/* Name + email */}
+              <div className="flex-1" style={{ minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span className="font-semi text-sm" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {m.name || m.email}
+                  </span>
+                  {isCurrentUser && (
+                    <span className="badge" style={{ fontSize: "0.65rem", padding: "1px 6px" }}>You</span>
+                  )}
+                  {m.role === "admin" && (
+                    <Crown size={12} color="var(--amber)" title="Admin" />
+                  )}
+                </div>
+                <div className="text-xs text-muted" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {m.email}
+                </div>
+              </div>
+
+              {/* Role selector */}
+              <select
+                className="input"
+                value={m.role}
+                onChange={e => handleRoleChange(m.userId, e.target.value)}
+                disabled={isCurrentUser}
+                style={{ width: 110, height: 32, fontSize: "0.8rem", flexShrink: 0 }}
+                title={isCurrentUser ? "You cannot change your own role" : `Change role for ${m.name || m.email}`}
+              >
+                {ROLE_OPTIONS.map(r => (
+                  <option key={r.value} value={r.value}>{r.label}</option>
+                ))}
+              </select>
+
+              {/* Remove button */}
+              <button
+                className="btn btn-ghost btn-xs"
+                style={{ color: "var(--text3)", flexShrink: 0 }}
+                onClick={() => handleRemove(m.userId, m.name || m.email)}
+                disabled={isCurrentUser}
+                title={isCurrentUser ? "You cannot remove yourself" : `Remove ${m.name || m.email}`}
+              >
+                <Trash2 size={12} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Role legend */}
+      <div className="card card-padded" style={{ background: "var(--bg3)" }}>
+        <div className="font-semi text-xs" style={{ marginBottom: 10, color: "var(--text2)" }}>Role permissions</div>
+        <div className="flex-col gap-xs">
+          {ROLE_OPTIONS.map(r => (
+            <div key={r.value} style={{ display: "flex", gap: 10, alignItems: "baseline" }}>
+              <span className="text-sm font-semi" style={{ width: 70, flexShrink: 0 }}>{r.label}</span>
+              <span className="text-xs text-muted">{r.desc}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 // ── Recycle Bin helpers ────────────────────────────────────────────────────────
 
@@ -835,6 +1052,9 @@ export default function Settings() {
         </div>
       </div>
       </>}
+
+      {/* ── Tab: Members ── */}
+      {tab === "members" && <MembersTab />}
 
       {/* ── Tab: Execution ── */}
       {tab === "execution" && <>

--- a/frontend/src/utils/roles.js
+++ b/frontend/src/utils/roles.js
@@ -1,0 +1,40 @@
+/**
+ * @module utils/roles
+ * @description Workspace role hierarchy for client-side UI gating (ACL-002).
+ *
+ * **Important:** The frontend role check is for UX only (hiding buttons,
+ * showing 403 pages).  The backend enforces authorization via
+ * `backend/src/middleware/requireRole.js` — the source of truth.
+ *
+ * If you add or reorder roles, update BOTH this file and the backend
+ * `requireRole.js` ROLE_WEIGHT map.
+ */
+
+/** Role hierarchy weights — higher = more privileged. Must match backend/src/middleware/requireRole.js. */
+const ROLE_WEIGHT = Object.freeze({ admin: 30, qa_lead: 20, viewer: 10 });
+
+/**
+ * Check if a workspace role meets a minimum required role.
+ * @param {string|null} userRole — The user's current workspace role.
+ * @param {string} requiredRole — The minimum role needed.
+ * @returns {boolean}
+ */
+export function hasMinimumRole(userRole, requiredRole) {
+  if (!requiredRole) return true;
+  const userW = ROLE_WEIGHT[userRole] || 0;
+  const reqW = ROLE_WEIGHT[requiredRole] || 0;
+  return userW >= reqW;
+}
+
+/**
+ * Check if a user object has the minimum required workspace role.
+ * Convenience wrapper for use with the `useAuth()` user object.
+ *
+ * @param {Object|null} user — The user object from useAuth().
+ * @param {string} role — Minimum role required.
+ * @returns {boolean}
+ */
+export function userHasRole(user, role) {
+  if (!user) return false;
+  return hasMinimumRole(user.workspaceRole, role);
+}


### PR DESCRIPTION
## Summary
Implements **ACL-001** (multi-tenancy) and **ACL-002** (RBAC) — the last two 🔴 Blockers before team/production deployment.
### ACL-001 — Multi-tenancy: workspace ownership on all entities
**Problem:** Every authenticated user sees every project, test, and run. There is no workspace, organisation, or team concept. `GET /api/tests` returns all tests to any authenticated user. This is a hard blocker for any commercial deployment — companies must not see each other's test data.
**Changes:**
- Migration adds `workspaces` table and `workspaceId` FK to `projects`, `tests`, `runs`, `activities`
- New `workspaceRepo.js` for workspace CRUD
- `workspaceId` included in JWT payload; `requireAuth` injects `req.workspaceId`
- All route and repository queries scoped to `workspaceId`
- Workspace creation added to onboarding flow
- Frontend `AuthContext` exposes `workspace`
### ACL-002 — Role-based access control (Admin / QA Lead / Viewer)
**Problem:** All authenticated users have identical permissions. Admin-only operations (settings, data deletion, user management) are only visually guarded on the frontend — the API accepts them from any authenticated user.
**Changes:**
- `workspace_members` table with `role` column (`admin`, `qa_lead`, `viewer`)
- `requireRole('admin')` and `requireRole('qa_lead')` middleware
- Destructive operations and settings gated behind role checks
- Frontend `ProtectedRoute` and action buttons check role from `AuthContext`
- Members / Role management tab in Settings


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rameshbabuprudhvi/sentri/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
