### PR TITLE
fix(workspaces): support workspace switching and correct active workspace selection

### DIFF
--- a/backend/src/database/repositories/workspaceRepo.js
+++ b/backend/src/database/repositories/workspaceRepo.js
@@ -56,6 +56,33 @@ export function getByUserId(userId) {
 }
 
 /**
+ * Resolve a user's preferred active workspace.
+ *
+ * Selection order:
+ * 1) `preferredWorkspaceId` if the user is a member.
+ * 2) A workspace the user owns (`ownerId = userId`), oldest first.
+ * 3) Any other membership, oldest first.
+ *
+ * @param {string} userId
+ * @param {string|null} [preferredWorkspaceId=null]
+ * @returns {Object|undefined}
+ */
+export function getPreferredForUser(userId, preferredWorkspaceId = null) {
+  const workspaces = getByUserId(userId);
+  if (!workspaces || workspaces.length === 0) return undefined;
+
+  if (preferredWorkspaceId) {
+    const preferred = workspaces.find(ws => ws.id === preferredWorkspaceId);
+    if (preferred) return preferred;
+  }
+
+  const owned = workspaces.find(ws => ws.ownerId === userId);
+  if (owned) return owned;
+
+  return workspaces[0];
+}
+
+/**
  * Get a user's membership in a specific workspace.
  * @param {string} workspaceId
  * @param {string} userId

--- a/backend/src/middleware/workspaceScope.js
+++ b/backend/src/middleware/workspaceScope.js
@@ -33,13 +33,17 @@ export function workspaceScope(req, res, next) {
   if (!req.authUser) return next();
 
   const { sub: userId, workspaceId: jwtWorkspaceId } = req.authUser;
+  const headerWorkspaceId = typeof req.headers["x-workspace-id"] === "string"
+    ? req.headers["x-workspace-id"].trim()
+    : "";
+  const requestedWorkspaceId = headerWorkspaceId || jwtWorkspaceId;
 
   // If the JWT contains a workspaceId hint, verify membership and resolve
   // the current role from the DB (never trust the JWT for authorization).
-  if (jwtWorkspaceId) {
-    const membership = workspaceRepo.getMembership(jwtWorkspaceId, userId);
+  if (requestedWorkspaceId) {
+    const membership = workspaceRepo.getMembership(requestedWorkspaceId, userId);
     if (membership) {
-      req.workspaceId = jwtWorkspaceId;
+      req.workspaceId = requestedWorkspaceId;
       req.userRole = membership.role;
       return next();
     }

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -277,16 +277,18 @@ function validatePasswordStrength(password) {
  * authorization from the database.
  *
  * @param {Object} user — User row from the database.
+ * @param {Object} [opts]
+ * @param {string|null} [opts.preferredWorkspaceId] - Workspace ID hint to keep active on refresh.
  * @returns {{ sub, email, name, role, workspaceId, jti }}
  */
-function buildJwtPayload(user) {
+function buildJwtPayload(user, opts = {}) {
   const jti = crypto.randomUUID();
   const payload = { sub: user.id, email: user.email, name: user.name, role: user.role, jti };
 
   // Include workspaceId as a routing hint (not for authorization)
-  const workspaces = workspaceRepo.getByUserId(user.id);
-  if (workspaces && workspaces.length > 0) {
-    payload.workspaceId = workspaces[0].id;
+  const activeWorkspace = workspaceRepo.getPreferredForUser(user.id, opts.preferredWorkspaceId || null);
+  if (activeWorkspace) {
+    payload.workspaceId = activeWorkspace.id;
   }
 
   return payload;
@@ -309,16 +311,18 @@ function ensureUserWorkspace(user) {
 /**
  * Build the user response object with workspace info for the frontend.
  * @param {Object} user — User row from the database.
+ * @param {Object} [opts]
+ * @param {string|null} [opts.preferredWorkspaceId] - Workspace ID hint to return as active.
  * @returns {Object}
  */
-function buildUserResponse(user) {
+function buildUserResponse(user, opts = {}) {
   const resp = { id: user.id, name: user.name, email: user.email, role: user.role, avatar: user.avatar || null };
 
-  const workspaces = workspaceRepo.getByUserId(user.id);
-  if (workspaces && workspaces.length > 0) {
-    resp.workspaceId = workspaces[0].id;
-    resp.workspaceName = workspaces[0].name;
-    resp.workspaceRole = workspaces[0].role;
+  const activeWorkspace = workspaceRepo.getPreferredForUser(user.id, opts.preferredWorkspaceId || null);
+  if (activeWorkspace) {
+    resp.workspaceId = activeWorkspace.id;
+    resp.workspaceName = activeWorkspace.name;
+    resp.workspaceRole = activeWorkspace.role;
   }
 
   return resp;
@@ -491,7 +495,10 @@ router.post("/logout", requireAuth, (req, res) => {
 router.get("/me", requireAuth, (req, res) => {
   const user = userRepo.getById(req.authUser.sub);
   if (!user) return res.status(404).json({ error: "User not found." });
-  return res.json({ ...buildUserResponse(user), createdAt: user.createdAt });
+  return res.json({
+    ...buildUserResponse(user, { preferredWorkspaceId: req.authUser.workspaceId || null }),
+    createdAt: user.createdAt,
+  });
 });
 
 /**
@@ -515,12 +522,12 @@ router.post("/refresh", requireAuth, (req, res) => {
   if (oldJti) revokedTokens.set(oldJti, oldExp);
 
   // Issue a fresh token with a new JTI (includes updated workspace context)
-  const payload = buildJwtPayload(user);
+  const payload = buildJwtPayload(user, { preferredWorkspaceId: req.authUser.workspaceId || null });
   const token = signJwt(payload, getJwtSecret());
   const exp   = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
   setAuthCookie(res, token, exp);
 
-  return res.json({ user: buildUserResponse(user) });
+  return res.json({ user: buildUserResponse(user, { preferredWorkspaceId: payload.workspaceId || null }) });
 });
 
 // ─── Email Verification (SEC-001) ────────────────────────────────────────────

--- a/backend/src/routes/workspaces.js
+++ b/backend/src/routes/workspaces.js
@@ -5,6 +5,8 @@
  * ### Endpoints
  * | Method | Path                                    | Description                   | Min Role |
  * |--------|-----------------------------------------|-------------------------------|----------|
+ * | GET    | `/api/workspaces`                       | List my workspaces            | viewer   |
+ * | POST   | `/api/workspaces/switch`                | Switch active workspace       | viewer   |
  * | GET    | `/api/workspaces/current`               | Get current workspace info    | viewer   |
  * | PATCH  | `/api/workspaces/current`               | Update workspace name/slug    | admin    |
  * | GET    | `/api/workspaces/current/members`       | List workspace members        | viewer   |
@@ -14,11 +16,31 @@
  */
 
 import { Router } from "express";
+import crypto from "crypto";
 import * as workspaceRepo from "../database/repositories/workspaceRepo.js";
 import * as userRepo from "../database/repositories/userRepo.js";
 import { requireRole, VALID_ROLES } from "../middleware/requireRole.js";
+import { cookieSameSite } from "../middleware/appSetup.js";
+import {
+  signJwt, getJwtSecret, revokedTokens, AUTH_COOKIE,
+} from "../middleware/authenticate.js";
 
 const router = Router();
+const EXP_COOKIE = "token_exp";
+const JWT_TTL_SEC = 8 * 60 * 60;
+
+/**
+ * Set auth cookies on response.
+ * @param {Object} res
+ * @param {string} token
+ * @param {number} expSec
+ */
+function setAuthCookie(res, token, expSec) {
+  const maxAge = JWT_TTL_SEC;
+  const sameSite = cookieSameSite();
+  res.appendHeader("Set-Cookie", `${AUTH_COOKIE}=${token}; Path=/; HttpOnly; Max-Age=${maxAge}${sameSite}`);
+  res.appendHeader("Set-Cookie", `${EXP_COOKIE}=${expSec}; Path=/; Max-Age=${maxAge}${sameSite}`);
+}
 
 // ─── Current workspace info ───────────────────────────────────────────────────
 
@@ -56,6 +78,59 @@ router.patch("/current", requireRole("admin"), (req, res) => {
   workspaceRepo.update(req.workspaceId, updates);
   const ws = workspaceRepo.getById(req.workspaceId);
   return res.json(ws);
+});
+
+/**
+ * List all workspaces for the current user.
+ * @route GET /api/workspaces
+ */
+router.get("/", (req, res) => {
+  const workspaces = workspaceRepo.getByUserId(req.authUser.sub);
+  return res.json(workspaces);
+});
+
+/**
+ * Switch active workspace and issue a fresh JWT cookie scoped to it.
+ * @route POST /api/workspaces/switch
+ */
+router.post("/switch", (req, res) => {
+  const { workspaceId } = req.body || {};
+  if (!workspaceId || typeof workspaceId !== "string") {
+    return res.status(400).json({ error: "workspaceId is required." });
+  }
+
+  const membership = workspaceRepo.getMembership(workspaceId, req.authUser.sub);
+  if (!membership) {
+    return res.status(403).json({ error: "You are not a member of that workspace." });
+  }
+
+  const user = userRepo.getById(req.authUser.sub);
+  if (!user) {
+    return res.status(404).json({ error: "User not found." });
+  }
+
+  const { jti: oldJti, exp: oldExp } = req.authUser;
+  if (oldJti) revokedTokens.set(oldJti, oldExp);
+
+  const jti = crypto.randomUUID();
+  const payload = {
+    sub: user.id,
+    email: user.email,
+    name: user.name,
+    role: user.role,
+    jti,
+    workspaceId,
+  };
+  const token = signJwt(payload, getJwtSecret(), JWT_TTL_SEC);
+  const exp = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
+  setAuthCookie(res, token, exp);
+
+  const ws = workspaceRepo.getById(workspaceId);
+  return res.json({
+    workspaceId,
+    workspaceName: ws?.name || null,
+    workspaceRole: membership.role,
+  });
 });
 
 // ─── Member management ────────────────────────────────────────────────────────

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -34,6 +34,7 @@ const files = [
   "tests/ssrf-protection.test.js",
   "tests/email-verification.test.js",
   "tests/postgres-adapter.test.js",
+  "tests/workspace-switch.test.js",
 ];
 
 let passed = 0;

--- a/backend/tests/workspace-switch.test.js
+++ b/backend/tests/workspace-switch.test.js
@@ -1,0 +1,125 @@
+/**
+ * @module tests/workspace-switch
+ * @description Verifies multi-workspace selection and switching flows.
+ */
+
+import assert from "node:assert/strict";
+import authRouter, { requireAuth } from "../src/routes/auth.js";
+import { workspaceScope } from "../src/middleware/workspaceScope.js";
+import workspacesRouter from "../src/routes/workspaces.js";
+import * as workspaceRepo from "../src/database/repositories/workspaceRepo.js";
+import { createTestContext } from "./helpers/test-base.js";
+
+const t = createTestContext();
+const { app, req } = t;
+
+let mounted = false;
+
+function mountRoutesOnce() {
+  if (mounted) return;
+  app.use("/api/auth", authRouter);
+  app.use("/api/workspaces", requireAuth, workspaceScope, workspacesRouter);
+  mounted = true;
+}
+
+async function main() {
+  mountRoutesOnce();
+  t.resetDb();
+  const env = t.setupEnv({ SKIP_EMAIL_VERIFICATION: "true" });
+
+  const server = app.listen(0);
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+
+  try {
+    const rameshEmail = `ramesh-${Date.now()}@test.local`;
+    const parniEmail = `parni-${Date.now()}@test.local`;
+    const password = "Password123!";
+
+    const ramesh = await t.registerAndLogin(base, {
+      name: "Ramesh",
+      email: rameshEmail,
+      password,
+    });
+    const parniInitial = await t.registerAndLogin(base, {
+      name: "Parni",
+      email: parniEmail,
+      password,
+    });
+
+    const rameshWorkspaceId = ramesh.payload.workspaceId;
+    const parniWorkspaceId = parniInitial.payload.workspaceId;
+    assert.ok(rameshWorkspaceId);
+    assert.ok(parniWorkspaceId);
+    assert.notEqual(rameshWorkspaceId, parniWorkspaceId);
+
+    let out = await req(base, "/api/workspaces/current/members", {
+      method: "POST",
+      token: ramesh.token,
+      body: { email: parniEmail, role: "viewer" },
+    });
+    assert.equal(out.res.status, 201);
+
+    // Parni logs in after being added to Ramesh's workspace.
+    out = await req(base, "/api/auth/login", {
+      method: "POST",
+      body: { email: parniEmail, password },
+    });
+    assert.equal(out.res.status, 200);
+    const parniToken = t.extractCookie(out.res, "access_token");
+    const parniPayload = t.decodeJwtPayload(parniToken);
+
+    // Login should keep Parni in her own (owned) workspace by default.
+    assert.equal(parniPayload.workspaceId, parniWorkspaceId);
+
+    out = await req(base, "/api/workspaces", { token: parniToken });
+    assert.equal(out.res.status, 200);
+    assert.equal(Array.isArray(out.json), true);
+    assert.equal(out.json.length >= 2, true);
+
+    // Switch to Ramesh's workspace.
+    out = await req(base, "/api/workspaces/switch", {
+      method: "POST",
+      token: parniToken,
+      body: { workspaceId: rameshWorkspaceId },
+    });
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.workspaceId, rameshWorkspaceId);
+    const switchedToken = t.extractCookie(out.res, "access_token");
+    assert.ok(switchedToken);
+
+    out = await req(base, "/api/workspaces/current", { token: switchedToken });
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.id, rameshWorkspaceId);
+
+    // Switch back to Parni's workspace.
+    out = await req(base, "/api/workspaces/switch", {
+      method: "POST",
+      token: switchedToken,
+      body: { workspaceId: parniWorkspaceId },
+    });
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.workspaceId, parniWorkspaceId);
+    const switchedBackToken = t.extractCookie(out.res, "access_token");
+    assert.ok(switchedBackToken);
+
+    out = await req(base, "/api/workspaces/current", { token: switchedBackToken });
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.id, parniWorkspaceId);
+
+    // Sanity check: role in Ramesh workspace stays viewer.
+    const membership = workspaceRepo.getMembership(rameshWorkspaceId, parniPayload.sub);
+    assert.equal(membership?.role, "viewer");
+
+    console.log("✅ workspace-switch: all checks passed");
+  } finally {
+    env.restore();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+main().catch((err) => {
+  console.error("❌ workspace-switch failed:", err);
+  process.exit(1);
+});
+

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -352,6 +352,10 @@ export const api = {
   // ── Workspace & Members (ACL-001, ACL-002) ───────────────────────────────────
   /** @returns {Promise<Object>} Current workspace details. */
   getWorkspace:      ()              => req("GET",    "/workspaces/current"),
+  /** @returns {Promise<Array>} All workspaces the current user can access. */
+  getWorkspaces:     ()              => req("GET",    "/workspaces"),
+  /** @param {string} workspaceId */
+  switchWorkspace:   (workspaceId)   => req("POST",   "/workspaces/switch", { workspaceId }),
   /** @param {Object} data - `{ name?, slug? }` */
   updateWorkspace:   (data)          => req("PATCH",  "/workspaces/current", data),
   /** @returns {Promise<Array>} List of workspace members with roles. */

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { LayoutDashboard, FlaskConical, FolderOpen, BarChart2, Briefcase, Layers, Zap, Settings, BookOpen, ExternalLink, MessageSquare } from "lucide-react";
 import AppLogo from "./AppLogo.jsx";
@@ -17,8 +17,38 @@ const NAV = [
 ];
 
 export default function Sidebar({ open }) {
-  const { user } = useAuth();
+  const { user, authFetch, switchWorkspace } = useAuth();
   const isAdmin = userHasRole(user, "admin");
+  const [workspaces, setWorkspaces] = useState([]);
+  const [switchingWorkspaceId, setSwitchingWorkspaceId] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!user) return;
+    authFetch("/api/workspaces")
+      .then(res => res.ok ? res.json() : [])
+      .then(data => {
+        if (!cancelled && Array.isArray(data)) setWorkspaces(data);
+      })
+      .catch(() => {
+        if (!cancelled) setWorkspaces([]);
+      });
+    return () => { cancelled = true; };
+  }, [authFetch, user?.id, user?.workspaceId]);
+
+  async function onWorkspaceChange(e) {
+    const nextId = e.target.value;
+    if (!nextId || nextId === user?.workspaceId) return;
+    setSwitchingWorkspaceId(nextId);
+    try {
+      await switchWorkspace(nextId);
+      window.location.reload();
+    } catch (err) {
+      alert(err.message || "Failed to switch workspace.");
+    } finally {
+      setSwitchingWorkspaceId("");
+    }
+  }
 
   return (
     <aside className={open ? "sidebar-open" : ""} style={{
@@ -36,6 +66,29 @@ export default function Sidebar({ open }) {
         <div style={{ padding: "6px 8px", borderRadius: "var(--radius)" }}>
           <div style={{ fontSize: "0.78rem", fontWeight: 600, color: "var(--text)" }}>{user?.workspaceName || "My Workspace"}</div>
           <div style={{ fontSize: "0.7rem", color: "var(--text3)", textTransform: "capitalize" }}>{user?.workspaceRole || "Personal"}</div>
+          {workspaces.length > 1 && (
+            <select
+              value={user?.workspaceId || ""}
+              onChange={onWorkspaceChange}
+              disabled={!!switchingWorkspaceId}
+              style={{
+                marginTop: 8,
+                width: "100%",
+                fontSize: "0.72rem",
+                background: "var(--surface)",
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius-sm)",
+                color: "var(--text)",
+                padding: "6px 7px",
+              }}
+            >
+              {workspaces.map((ws) => (
+                <option key={ws.id} value={ws.id}>
+                  {ws.name} ({ws.role.replace("_", " ")})
+                </option>
+              ))}
+            </select>
+          )}
         </div>
       </div>
 

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -188,6 +188,41 @@ export function AuthProvider({ children }) {
   }
 
   /**
+   * Switch active workspace for the current session.
+   * The backend issues a fresh JWT cookie with the requested workspace hint.
+   *
+   * @param {string} workspaceId
+   * @returns {Promise<Object>} Updated user profile.
+   */
+  async function switchWorkspace(workspaceId) {
+    if (!workspaceId || !user) return user;
+    const res = await fetch(`${API_BASE}/api/workspaces/switch`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json", "X-CSRF-Token": getCsrfToken() },
+      body: JSON.stringify({ workspaceId }),
+    });
+    if (res.status === 401) {
+      doLogout(true);
+      throw new Error("Session expired. Please sign in again.");
+    }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.error || "Failed to switch workspace.");
+    }
+    const nextUser = sanitiseUser({
+      ...user,
+      workspaceId: data.workspaceId || null,
+      workspaceName: data.workspaceName || null,
+      workspaceRole: data.workspaceRole || null,
+    });
+    localStorage.setItem(USER_KEY, JSON.stringify(nextUser));
+    setUser(nextUser);
+    scheduleRefresh();
+    return nextUser;
+  }
+
+  /**
    * Authenticated fetch wrapper.
    * Sends `credentials: "include"` so the HttpOnly cookie is attached automatically.
    * Injects X-CSRF-Token for mutating requests.
@@ -211,7 +246,7 @@ export function AuthProvider({ children }) {
   }, []); // eslint-disable-line
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, authFetch, loading }}>
+    <AuthContext.Provider value={{ user, login, logout, switchWorkspace, authFetch, loading }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
### Motivation

- Users invited into older workspaces could get their JWT routed to the wrong workspace on login because `buildJwtPayload` always selected the first membership, and there was no mechanism to switch workspaces at runtime.
- Provide a secure server-side switch and a frontend UX to let users select their active workspace without losing role resolution from the DB.

### Description

- Add `getPreferredForUser(userId, preferredWorkspaceId)` to `workspaceRepo` to prefer an explicit workspace hint, then a user-owned workspace, then fall back to the first membership.
- Update `buildJwtPayload` and `buildUserResponse` in `auth.js` to use the preferred workspace hint so JWTs and `/me` responses reflect the correct active workspace.
- Extend `workspaceScope` middleware to honor an `X-Workspace-Id` header (validated against membership) and otherwise fall back to the JWT hint or memberships. 
- Implement workspace endpoints in `workspaces.js`: `GET /api/workspaces` to list memberships and `POST /api/workspaces/switch` to validate membership, revoke the old JTI, issue a fresh JWT cookie scoped to the requested workspace, and return workspace info. 
- Wire frontend support: `api.getWorkspaces()` and `api.switchWorkspace()`, add `switchWorkspace()` to `AuthContext`, and add a workspace selector in the Sidebar that calls the switch API and reloads on success. 
- Add integration test `backend/tests/workspace-switch.test.js` covering invite → login → list → switch → switch-back flows and include it in `backend/tests/run-tests.js`.

### Testing

- Ran static syntax checks with `node --check` for the modified backend files and the new test file which succeeded. 
- Added an integration unit test `backend/tests/workspace-switch.test.js` and wired it into the test runner (`backend/tests/run-tests.js`).
- Attempted to execute the integration test directly (`node backend/tests/workspace-switch.test.js`) but full runtime execution could not be completed in this environment due to inconsistent/missing `node_modules` (package resolution failed for `express`), so end-to-end runtime verification should be performed in CI or a local environment where `npm install` has been run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25f7a4a5483268d2df0db6f959412)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rameshbabuprudhvi/sentri/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
