### PR TITLE
feat(security): implement nonce CSP and account export/delete (SEC-002, SEC-003) + tests

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -905,14 +905,14 @@ The following have been implemented and are no longer open:
 - **Per-user audit trail** ✅: Every activity log entry records `userId` and `userName` (migration 004). The `actor(req)` utility in `utils/actor.js` extracts identity from `req.authUser` (JWT payload includes `name`). Bulk approve/reject/restore actions log per-test entries with the acting user's identity.
 - **Artifact authentication** ✅: The `/artifacts` route is protected by HMAC-SHA256 signed `?token=&exp=` query-param tokens (1 hour TTL, configurable via `ARTIFACT_TOKEN_TTL_MS`). `ARTIFACT_SECRET` is required in production; dev uses a random per-process secret. `signArtifactUrl()` in `middleware/appSetup.js` generates signed URLs; all artifact producers (screenshots, videos, traces) use it. `Cache-Control: private, no-store` prevents browsers from caching expiring URLs.
 - **Secrets scanning** ✅: Gitleaks runs on every PR and push to `main` via the `secrets` CI job (`.github/workflows/ci.yml`). Both `lint` and `build` jobs depend on it, gating the entire pipeline. Configuration in `.github/.gitleaks.toml` extends the default ruleset with allowlists for CI placeholders and `.env.example` files.
+- **Nonce-based CSP** ✅: Per-request nonce generated via `crypto.randomBytes(16)` in `middleware/appSetup.js`, passed to Helmet CSP `scriptSrc` as `'nonce-<value>'`. Vite `transformIndexHtml` plugin injects `nonce="__CSP_NONCE__"` on all `<script>` tags; `serveIndexWithNonce()` replaces the placeholder at serve-time. `'unsafe-inline'` removed from `scriptSrc` (SEC-002).
+- **GDPR/CCPA account export & deletion** ✅: `GET /api/auth/export` returns a JSON archive of all user-owned data (workspaces, projects, tests, runs, activities, schedules, notification settings) with `passwordHash` stripped. `DELETE /api/auth/account` hard-deletes the user and all owned data in a single transaction. Both require password confirmation (403 on mismatch). Frontend Account tab in Settings with two-click confirm flow (SEC-003).
 
 ### Known Security Gaps (TODO)
 
 The following are **not yet implemented** but should be addressed before production:
 
 - **Error tracking**: No external error tracking (Sentry, etc.) is configured. Errors are only visible in server logs and browser console.
-- **Nonce-based CSP**: `'unsafe-inline'` should be replaced with nonce-based script allowlisting (SEC-002).
-- **GDPR/CCPA**: No account data export or deletion endpoints exist yet (SEC-003).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,7 +100,7 @@ The following items have been verified complete against the codebase and are **n
 
 ### SEC-002 — Nonce-based Content Security Policy 🟡 High
 
-**Status:** 🔲 Planned | **Effort:** M | **Source:** Quality Review (GAP-03)
+**Status:** ✅ Complete | **Effort:** M | **Source:** Quality Review (GAP-03)
 
 **Problem:** `appSetup.js:55` uses `'unsafe-inline'` for both `scriptSrc` and `styleSrc`. An inline comment acknowledges "replace with nonces in prod." Without nonces, any XSS injection can execute inline scripts — CSP provides no real protection.
 
@@ -117,7 +117,7 @@ The following items have been verified complete against the codebase and are **n
 
 ### SEC-003 — GDPR / CCPA account data export and deletion 🟡 High
 
-**Status:** 🔲 Planned | **Effort:** M | **Source:** Quality Review (GAP-04)
+**Status:** ✅ Complete | **Effort:** M | **Source:** Quality Review (GAP-04)
 
 **Problem:** There is no way for a user to export their data or delete their account. GDPR Article 17 (right to erasure) and Article 20 (data portability) are legal requirements for EU deployments. CCPA creates equivalent expectations for US users.
 

--- a/backend/src/database/repositories/accountRepo.js
+++ b/backend/src/database/repositories/accountRepo.js
@@ -1,0 +1,167 @@
+/**
+ * @module database/repositories/accountRepo
+ * @description Account-level data export and cascade deletion (SEC-003).
+ *
+ * Encapsulates the workspace-scoped queries needed for GDPR/CCPA data
+ * portability (export) and right-to-erasure (deletion).  All DB access
+ * goes through this module — route handlers never write raw SQL.
+ */
+
+import { getDatabase } from "../sqlite.js";
+import * as userRepo from "./userRepo.js";
+import * as runLogRepo from "./runLogRepo.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a comma-separated placeholder string for a parameterised IN clause.
+ *
+ * @param {string[]} ids
+ * @returns {string} e.g. `"?, ?, ?"`
+ */
+function placeholders(ids) {
+  return ids.map(() => "?").join(", ");
+}
+
+// ─── Export ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a JSON-serialisable export payload for all data owned by a user.
+ *
+ * Scope:
+ * - User profile (sensitive fields stripped)
+ * - Workspaces owned by the user
+ * - Workspace memberships
+ * - Projects, tests, runs, activities in owned workspaces
+ * - Notification settings and schedules for owned projects
+ *
+ * @param {string} userId
+ * @returns {Object}
+ */
+export function buildAccountExport(userId) {
+  const db = getDatabase();
+  const rawUser = userRepo.getById(userId);
+  // Strip sensitive fields — never expose the password hash in exports.
+  const { passwordHash, ...safeUser } = rawUser || {};
+
+  const ownedWorkspaces = db
+    .prepare("SELECT * FROM workspaces WHERE ownerId = ? ORDER BY createdAt ASC")
+    .all(userId);
+  const ownedWorkspaceIds = ownedWorkspaces.map((w) => w.id);
+  const membershipRows = db
+    .prepare("SELECT * FROM workspace_members WHERE userId = ? ORDER BY joinedAt ASC")
+    .all(userId);
+
+  if (ownedWorkspaceIds.length === 0) {
+    return {
+      exportedAt: new Date().toISOString(),
+      user: safeUser,
+      ownedWorkspaces: [],
+      memberships: membershipRows,
+      workspaceMembers: [],
+      projects: [],
+      tests: [],
+      runs: [],
+      activities: [],
+      notificationSettings: [],
+      schedules: [],
+    };
+  }
+
+  const wsph = placeholders(ownedWorkspaceIds);
+  const projects = db.prepare(`SELECT * FROM projects WHERE workspaceId IN (${wsph})`).all(...ownedWorkspaceIds);
+  const projectIds = projects.map((p) => p.id);
+
+  const tests = db.prepare(`SELECT * FROM tests WHERE workspaceId IN (${wsph})`).all(...ownedWorkspaceIds);
+  const runs = db.prepare(`SELECT * FROM runs WHERE workspaceId IN (${wsph})`).all(...ownedWorkspaceIds);
+  const activities = db.prepare(`SELECT * FROM activities WHERE workspaceId IN (${wsph})`).all(...ownedWorkspaceIds);
+  const workspaceMembers = db.prepare(`SELECT * FROM workspace_members WHERE workspaceId IN (${wsph})`).all(...ownedWorkspaceIds);
+
+  let notificationSettings = [];
+  let schedules = [];
+  if (projectIds.length > 0) {
+    const pph = placeholders(projectIds);
+    notificationSettings = db.prepare(`SELECT * FROM notification_settings WHERE projectId IN (${pph})`).all(...projectIds);
+    schedules = db.prepare(`SELECT * FROM schedules WHERE projectId IN (${pph})`).all(...projectIds);
+  }
+
+  return {
+    exportedAt: new Date().toISOString(),
+    user: safeUser,
+    ownedWorkspaces,
+    memberships: membershipRows,
+    workspaceMembers,
+    projects,
+    tests,
+    runs,
+    activities,
+    notificationSettings,
+    schedules,
+  };
+}
+
+// ─── Deletion ─────────────────────────────────────────────────────────────────
+
+/**
+ * Hard-delete a user account and all owned workspace data in a single
+ * transaction.  This is the GDPR Article 17 "right to erasure" implementation.
+ *
+ * Cascade order:
+ * 1. Per-project children: notification_settings, schedules
+ * 2. Per-workspace children: activities, run_logs → runs, tests, projects
+ * 3. Workspace membership and workspace rows
+ * 4. User-level rows: workspace_members (non-owned), oauth_ids,
+ *    password_reset_tokens, verification_tokens, users
+ *
+ * @param {string} userId
+ * @throws {Error} If the transaction fails (caller should catch and 500).
+ */
+export function deleteAccount(userId) {
+  const db = getDatabase();
+
+  const removeAccount = db.transaction(() => {
+    const ownedWorkspaceRows = db
+      .prepare("SELECT id FROM workspaces WHERE ownerId = ?")
+      .all(userId);
+    const ownedWorkspaceIds = ownedWorkspaceRows.map((w) => w.id);
+
+    if (ownedWorkspaceIds.length > 0) {
+      const wsph = placeholders(ownedWorkspaceIds);
+
+      // Collect owned project IDs for child-table cleanup
+      const ownedProjectRows = db
+        .prepare(`SELECT id FROM projects WHERE workspaceId IN (${wsph})`)
+        .all(...ownedWorkspaceIds);
+      const ownedProjectIds = ownedProjectRows.map((p) => p.id);
+
+      if (ownedProjectIds.length > 0) {
+        const pph = placeholders(ownedProjectIds);
+        db.prepare(`DELETE FROM notification_settings WHERE projectId IN (${pph})`).run(...ownedProjectIds);
+        db.prepare(`DELETE FROM schedules WHERE projectId IN (${pph})`).run(...ownedProjectIds);
+      }
+
+      // Delete run_logs for all runs in owned workspaces
+      const runRows = db.prepare(`SELECT id FROM runs WHERE workspaceId IN (${wsph})`).all(...ownedWorkspaceIds);
+      const runIds = runRows.map((r) => r.id);
+      if (runIds.length > 0) {
+        runLogRepo.deleteByRunIds(runIds);
+      }
+
+      db.prepare(`DELETE FROM activities WHERE workspaceId IN (${wsph})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM runs WHERE workspaceId IN (${wsph})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM tests WHERE workspaceId IN (${wsph})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM projects WHERE workspaceId IN (${wsph})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM workspace_members WHERE workspaceId IN (${wsph})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM workspaces WHERE id IN (${wsph})`).run(...ownedWorkspaceIds);
+    }
+
+    // Clean up user-level rows (non-owned workspace memberships, OAuth, tokens)
+    db.prepare("DELETE FROM workspace_members WHERE userId = ?").run(userId);
+    db.prepare("DELETE FROM oauth_ids WHERE userId = ?").run(userId);
+    db.prepare("DELETE FROM password_reset_tokens WHERE userId = ?").run(userId);
+    db.prepare("DELETE FROM verification_tokens WHERE userId = ?").run(userId);
+    db.prepare("DELETE FROM users WHERE id = ?").run(userId);
+  });
+
+  removeAccount();
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -31,7 +31,7 @@ import { closeQueue } from "./queue.js";
 import { startWorker, stopWorker } from "./workers/runWorker.js";
 
 // ─── App + global middleware ──────────────────────────────────────────────────
-import { app } from "./middleware/appSetup.js";
+import { app, serveIndexWithNonce } from "./middleware/appSetup.js";
 import { workspaceScope } from "./middleware/workspaceScope.js";
 
 // ─── Route modules ────────────────────────────────────────────────────────────
@@ -265,6 +265,13 @@ app.get("/health/ready", async (_req, res) => {
 
   res.status(allOk ? 200 : 503).json({ ok: allOk, checks });
 });
+
+// ─── SPA fallback (SEC-002: nonce injection) ─────────────────────────────────
+// In Docker, nginx proxies unmatched paths to the backend via @backend_spa.
+// This catch-all serves the Vite-built index.html with __CSP_NONCE__ replaced
+// by the per-request nonce so inline scripts pass CSP validation.
+// Must be mounted AFTER all API routes and health checks.
+app.get("*", serveIndexWithNonce);
 
 // ─── Start server ─────────────────────────────────────────────────────────────
 const PORT = process.env.PORT || 3001;

--- a/backend/src/middleware/appSetup.js
+++ b/backend/src/middleware/appSetup.js
@@ -8,6 +8,7 @@
  * ### Exports
  * - {@link app} — The Express application instance.
  * - {@link ARTIFACTS_DIR} — Absolute path to the Playwright artifacts directory.
+ * - {@link serveIndexWithNonce} — SPA fallback handler that injects the CSP nonce (SEC-002).
  *
  * @example
  * import { app, ARTIFACTS_DIR } from "./middleware/appSetup.js";

--- a/backend/src/middleware/appSetup.js
+++ b/backend/src/middleware/appSetup.js
@@ -19,6 +19,7 @@ import cors from "cors";
 import helmet from "helmet";
 import { rateLimit } from "express-rate-limit";
 import crypto from "crypto";
+import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
@@ -54,8 +55,6 @@ app.set("trust proxy", 1);
 app.use((req, res, next) => {
   const nonce = crypto.randomBytes(16).toString("base64");
   res.locals.cspNonce = nonce;
-  // Exposed for reverse proxies / edge HTML rewriters that inject nonce attrs.
-  res.setHeader("X-CSP-Nonce", nonce);
   next();
 });
 
@@ -470,3 +469,54 @@ app.use("/artifacts", (req, res, next) => {
     res.setHeader("Cache-Control", "private, no-store");
   },
 }));
+
+// ─── SEC-002: Serve index.html with nonce placeholder replaced ───────────────
+// In production the Vite-built SPA is served as static files. The build output
+// contains `nonce="__CSP_NONCE__"` placeholders on all `<script>` tags (injected
+// by the `cspNoncePlugin` in `vite.config.js`). This middleware replaces the
+// placeholder with the real per-request nonce so the scripts pass CSP validation.
+//
+// The replacement is done on-the-fly for `index.html` only — it is a small file
+// and the string replace is negligible. All other static assets are served as-is.
+
+/** @type {string|null} Cached index.html template with `__CSP_NONCE__` placeholders. */
+let _indexHtmlTemplate = null;
+
+/**
+ * Read and cache the built `index.html` from the frontend dist directory.
+ * Returns `null` when the file does not exist (e.g. dev mode where Vite serves).
+ *
+ * @returns {string|null}
+ */
+function getIndexHtmlTemplate() {
+  if (_indexHtmlTemplate !== null) return _indexHtmlTemplate;
+  const distIndex = path.join(__dirname, "..", "..", "..", "frontend", "dist", "index.html");
+  try {
+    _indexHtmlTemplate = fs.readFileSync(distIndex, "utf-8");
+  } catch {
+    _indexHtmlTemplate = "";
+  }
+  return _indexHtmlTemplate || null;
+}
+
+/**
+ * Middleware that serves `index.html` with `__CSP_NONCE__` replaced by the
+ * per-request nonce from `res.locals.cspNonce`.
+ *
+ * Must be mounted **after** all API routes and static file middleware so it
+ * only catches SPA navigation requests (HTML pages, not API calls or assets).
+ *
+ * @param {Object} req
+ * @param {Object} res
+ */
+export function serveIndexWithNonce(req, res) {
+  const template = getIndexHtmlTemplate();
+  if (!template) {
+    return res.status(404).send("Frontend build not found.");
+  }
+  const nonce = res.locals.cspNonce || "";
+  const html = template.replaceAll("__CSP_NONCE__", nonce);
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache");
+  res.send(html);
+}

--- a/backend/src/middleware/appSetup.js
+++ b/backend/src/middleware/appSetup.js
@@ -48,14 +48,22 @@ app.set("trust proxy", 1);
 // ─── Global middleware ────────────────────────────────────────────────────────
 
 // Security headers: X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security, etc.
-// CSP is configured with a baseline policy that allows the SPA to function while
-// blocking inline script injection (XSS mitigation). Tighten further in production
-// by replacing 'unsafe-inline' with nonce-based or hash-based script allowlisting.
+// SEC-002: Generate a per-request nonce and allow scripts via `'nonce-<value>'`
+// instead of `'unsafe-inline'`. This keeps inline bootstrap scripts functional
+// while preserving CSP's XSS protections.
+app.use((req, res, next) => {
+  const nonce = crypto.randomBytes(16).toString("base64");
+  res.locals.cspNonce = nonce;
+  // Exposed for reverse proxies / edge HTML rewriters that inject nonce attrs.
+  res.setHeader("X-CSP-Nonce", nonce);
+  next();
+});
+
 app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc:     ["'self'"],
-      scriptSrc:      ["'self'", "'unsafe-inline'"],   // needed by Vite in dev; replace with nonces in prod
+      scriptSrc:      ["'self'", (req, res) => `'nonce-${res.locals.cspNonce}'`],
       styleSrc:       ["'self'", "'unsafe-inline'"],   // inline styles used throughout the SPA
       imgSrc:         ["'self'", "data:", "blob:"],    // data: for canvas favicons, blob: for screenshots
       connectSrc:     ["'self'"],                      // API + SSE calls — same origin only

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -10,6 +10,8 @@
  * | POST   | `/api/auth/logout`            | Token revocation + cookie clear      |
  * | POST   | `/api/auth/refresh`           | Refresh session (extend cookie TTL)  |
  * | GET    | `/api/auth/me`                | Return current user from cookie      |
+ * | GET    | `/api/auth/export`            | Export user-owned account data (SEC-003) |
+ * | DELETE | `/api/auth/account`           | Delete account + owned data (SEC-003) |
  * | GET    | `/api/auth/verify`            | Verify email via token (SEC-001)     |
  * | POST   | `/api/auth/resend-verification` | Resend verification email (SEC-001)|
  * | POST   | `/api/auth/forgot-password`   | Request a password reset token       |
@@ -38,6 +40,7 @@ import * as userRepo from "../database/repositories/userRepo.js";
 import * as resetTokenRepo from "../database/repositories/passwordResetTokenRepo.js";
 import * as verificationTokenRepo from "../database/repositories/verificationTokenRepo.js";
 import * as workspaceRepo from "../database/repositories/workspaceRepo.js";
+import { getDatabase } from "../database/sqlite.js";
 import { formatLogLine } from "../utils/logFormatter.js";
 import { sendVerificationEmail } from "../utils/emailSender.js";
 import { buildJwtPayload, buildUserResponse } from "../utils/authWorkspace.js";
@@ -445,6 +448,176 @@ router.get("/me", requireAuth, (req, res) => {
   const user = userRepo.getById(req.authUser.sub);
   if (!user) return res.status(404).json({ error: "User not found." });
   return res.json({ ...buildUserResponse(user, req.authUser.workspaceId), createdAt: user.createdAt });
+});
+
+// ─── Account export / deletion (SEC-003) ─────────────────────────────────────
+
+/**
+ * Verify the authenticated user's password for sensitive account actions.
+ *
+ * @param {Object} user
+ * @param {string} password
+ * @returns {Promise<boolean>}
+ */
+async function verifyAccountPassword(user, password) {
+  if (!user?.passwordHash) return false;
+  if (typeof password !== "string" || !password) return false;
+  return verifyPassword(password, user.passwordHash);
+}
+
+/**
+ * Build an export payload for all user-owned account data.
+ *
+ * Scope:
+ * - User profile
+ * - Workspaces owned by the user
+ * - Owned workspace members
+ * - Projects/tests/runs/activities in owned workspaces
+ * - Notification settings and schedules for owned projects
+ *
+ * @param {string} userId
+ * @returns {Object}
+ */
+function buildAccountExport(userId) {
+  const db = getDatabase();
+  const user = userRepo.getById(userId);
+  const ownedWorkspaces = db.prepare("SELECT * FROM workspaces WHERE ownerId = ? ORDER BY createdAt ASC").all(userId);
+  const ownedWorkspaceIds = ownedWorkspaces.map((w) => w.id);
+  const membershipRows = db.prepare("SELECT * FROM workspace_members WHERE userId = ? ORDER BY joinedAt ASC").all(userId);
+
+  if (ownedWorkspaceIds.length === 0) {
+    return {
+      exportedAt: new Date().toISOString(),
+      user,
+      ownedWorkspaces: [],
+      memberships: membershipRows,
+      workspaceMembers: [],
+      projects: [],
+      tests: [],
+      runs: [],
+      activities: [],
+      notificationSettings: [],
+      schedules: [],
+    };
+  }
+
+  const placeholders = ownedWorkspaceIds.map(() => "?").join(", ");
+  const projects = db.prepare(`SELECT * FROM projects WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
+  const projectIds = projects.map((p) => p.id);
+  const projectPlaceholders = projectIds.length ? projectIds.map(() => "?").join(", ") : "";
+
+  const tests = db.prepare(`SELECT * FROM tests WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
+  const runs = db.prepare(`SELECT * FROM runs WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
+  const activities = db.prepare(`SELECT * FROM activities WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
+  const workspaceMembers = db.prepare(`SELECT * FROM workspace_members WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
+  const notificationSettings = projectIds.length
+    ? db.prepare(`SELECT * FROM notification_settings WHERE projectId IN (${projectPlaceholders})`).all(...projectIds)
+    : [];
+  const schedules = projectIds.length
+    ? db.prepare(`SELECT * FROM schedules WHERE projectId IN (${projectPlaceholders})`).all(...projectIds)
+    : [];
+
+  return {
+    exportedAt: new Date().toISOString(),
+    user,
+    ownedWorkspaces,
+    memberships: membershipRows,
+    workspaceMembers,
+    projects,
+    tests,
+    runs,
+    activities,
+    notificationSettings,
+    schedules,
+  };
+}
+
+/**
+ * Export all user-owned account data as JSON (GDPR/CCPA data portability).
+ * Requires password confirmation via `x-account-password` header.
+ *
+ * @route GET /api/auth/export
+ * @returns {200} JSON export payload.
+ * @returns {400} Missing password.
+ * @returns {401} Invalid password.
+ */
+router.get("/export", requireAuth, async (req, res) => {
+  const user = userRepo.getById(req.authUser.sub);
+  if (!user) return res.status(404).json({ error: "User not found." });
+
+  const password = req.headers["x-account-password"];
+  if (typeof password !== "string" || !password) {
+    return res.status(400).json({ error: "Password confirmation is required." });
+  }
+  const valid = await verifyAccountPassword(user, password);
+  if (!valid) {
+    return res.status(401).json({ error: "Password confirmation failed." });
+  }
+
+  const data = buildAccountExport(user.id);
+  return res.json(data);
+});
+
+/**
+ * Delete account and all user-owned workspace data (GDPR right to erasure).
+ * Requires password confirmation.
+ *
+ * @route DELETE /api/auth/account
+ * @param {Object} req.body
+ * @param {string} req.body.password - Account password confirmation.
+ * @returns {200} `{ ok: true }` on success.
+ */
+router.delete("/account", requireAuth, async (req, res) => {
+  const user = userRepo.getById(req.authUser.sub);
+  if (!user) return res.status(404).json({ error: "User not found." });
+
+  const password = req.body?.password;
+  if (typeof password !== "string" || !password) {
+    return res.status(400).json({ error: "Password confirmation is required." });
+  }
+  const valid = await verifyAccountPassword(user, password);
+  if (!valid) {
+    return res.status(401).json({ error: "Password confirmation failed." });
+  }
+
+  const db = getDatabase();
+  const removeAccount = db.transaction(() => {
+    const ownedWorkspaceRows = db.prepare("SELECT id FROM workspaces WHERE ownerId = ?").all(user.id);
+    const ownedWorkspaceIds = ownedWorkspaceRows.map((w) => w.id);
+
+    if (ownedWorkspaceIds.length > 0) {
+      const placeholders = ownedWorkspaceIds.map(() => "?").join(", ");
+      const ownedProjectRows = db.prepare(`SELECT id FROM projects WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
+      const ownedProjectIds = ownedProjectRows.map((p) => p.id);
+      if (ownedProjectIds.length > 0) {
+        const projectPlaceholders = ownedProjectIds.map(() => "?").join(", ");
+        db.prepare(`DELETE FROM notification_settings WHERE projectId IN (${projectPlaceholders})`).run(...ownedProjectIds);
+        db.prepare(`DELETE FROM schedules WHERE projectId IN (${projectPlaceholders})`).run(...ownedProjectIds);
+      }
+      db.prepare(`DELETE FROM activities WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM runs WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM tests WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM projects WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM workspace_members WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
+      db.prepare(`DELETE FROM workspaces WHERE id IN (${placeholders})`).run(...ownedWorkspaceIds);
+    }
+
+    db.prepare("DELETE FROM workspace_members WHERE userId = ?").run(user.id);
+    db.prepare("DELETE FROM oauth_ids WHERE userId = ?").run(user.id);
+    db.prepare("DELETE FROM password_reset_tokens WHERE userId = ?").run(user.id);
+    db.prepare("DELETE FROM verification_tokens WHERE userId = ?").run(user.id);
+    db.prepare("DELETE FROM users WHERE id = ?").run(user.id);
+  });
+
+  try {
+    removeAccount();
+  } catch (err) {
+    console.error(formatLogLine("error", null, `[auth/account] Delete failed for user ${user.id}: ${err.message}`));
+    return res.status(500).json({ error: "Failed to delete account." });
+  }
+
+  clearAuthCookies(res);
+  return res.json({ ok: true, message: "Account and owned data deleted." });
 });
 
 /**

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -40,7 +40,7 @@ import * as userRepo from "../database/repositories/userRepo.js";
 import * as resetTokenRepo from "../database/repositories/passwordResetTokenRepo.js";
 import * as verificationTokenRepo from "../database/repositories/verificationTokenRepo.js";
 import * as workspaceRepo from "../database/repositories/workspaceRepo.js";
-import { getDatabase } from "../database/sqlite.js";
+import * as accountRepo from "../database/repositories/accountRepo.js";
 import { formatLogLine } from "../utils/logFormatter.js";
 import { sendVerificationEmail } from "../utils/emailSender.js";
 import { buildJwtPayload, buildUserResponse } from "../utils/authWorkspace.js";
@@ -466,80 +466,13 @@ async function verifyAccountPassword(user, password) {
 }
 
 /**
- * Build an export payload for all user-owned account data.
- *
- * Scope:
- * - User profile
- * - Workspaces owned by the user
- * - Owned workspace members
- * - Projects/tests/runs/activities in owned workspaces
- * - Notification settings and schedules for owned projects
- *
- * @param {string} userId
- * @returns {Object}
- */
-function buildAccountExport(userId) {
-  const db = getDatabase();
-  const user = userRepo.getById(userId);
-  const ownedWorkspaces = db.prepare("SELECT * FROM workspaces WHERE ownerId = ? ORDER BY createdAt ASC").all(userId);
-  const ownedWorkspaceIds = ownedWorkspaces.map((w) => w.id);
-  const membershipRows = db.prepare("SELECT * FROM workspace_members WHERE userId = ? ORDER BY joinedAt ASC").all(userId);
-
-  if (ownedWorkspaceIds.length === 0) {
-    return {
-      exportedAt: new Date().toISOString(),
-      user,
-      ownedWorkspaces: [],
-      memberships: membershipRows,
-      workspaceMembers: [],
-      projects: [],
-      tests: [],
-      runs: [],
-      activities: [],
-      notificationSettings: [],
-      schedules: [],
-    };
-  }
-
-  const placeholders = ownedWorkspaceIds.map(() => "?").join(", ");
-  const projects = db.prepare(`SELECT * FROM projects WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
-  const projectIds = projects.map((p) => p.id);
-  const projectPlaceholders = projectIds.length ? projectIds.map(() => "?").join(", ") : "";
-
-  const tests = db.prepare(`SELECT * FROM tests WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
-  const runs = db.prepare(`SELECT * FROM runs WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
-  const activities = db.prepare(`SELECT * FROM activities WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
-  const workspaceMembers = db.prepare(`SELECT * FROM workspace_members WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
-  const notificationSettings = projectIds.length
-    ? db.prepare(`SELECT * FROM notification_settings WHERE projectId IN (${projectPlaceholders})`).all(...projectIds)
-    : [];
-  const schedules = projectIds.length
-    ? db.prepare(`SELECT * FROM schedules WHERE projectId IN (${projectPlaceholders})`).all(...projectIds)
-    : [];
-
-  return {
-    exportedAt: new Date().toISOString(),
-    user,
-    ownedWorkspaces,
-    memberships: membershipRows,
-    workspaceMembers,
-    projects,
-    tests,
-    runs,
-    activities,
-    notificationSettings,
-    schedules,
-  };
-}
-
-/**
  * Export all user-owned account data as JSON (GDPR/CCPA data portability).
  * Requires password confirmation via `x-account-password` header.
  *
  * @route GET /api/auth/export
  * @returns {200} JSON export payload.
  * @returns {400} Missing password.
- * @returns {401} Invalid password.
+ * @returns {403} Invalid password.
  */
 router.get("/export", requireAuth, async (req, res) => {
   const user = userRepo.getById(req.authUser.sub);
@@ -551,10 +484,10 @@ router.get("/export", requireAuth, async (req, res) => {
   }
   const valid = await verifyAccountPassword(user, password);
   if (!valid) {
-    return res.status(401).json({ error: "Password confirmation failed." });
+    return res.status(403).json({ error: "Password confirmation failed." });
   }
 
-  const data = buildAccountExport(user.id);
+  const data = accountRepo.buildAccountExport(user.id);
   return res.json(data);
 });
 
@@ -577,40 +510,11 @@ router.delete("/account", requireAuth, async (req, res) => {
   }
   const valid = await verifyAccountPassword(user, password);
   if (!valid) {
-    return res.status(401).json({ error: "Password confirmation failed." });
+    return res.status(403).json({ error: "Password confirmation failed." });
   }
 
-  const db = getDatabase();
-  const removeAccount = db.transaction(() => {
-    const ownedWorkspaceRows = db.prepare("SELECT id FROM workspaces WHERE ownerId = ?").all(user.id);
-    const ownedWorkspaceIds = ownedWorkspaceRows.map((w) => w.id);
-
-    if (ownedWorkspaceIds.length > 0) {
-      const placeholders = ownedWorkspaceIds.map(() => "?").join(", ");
-      const ownedProjectRows = db.prepare(`SELECT id FROM projects WHERE workspaceId IN (${placeholders})`).all(...ownedWorkspaceIds);
-      const ownedProjectIds = ownedProjectRows.map((p) => p.id);
-      if (ownedProjectIds.length > 0) {
-        const projectPlaceholders = ownedProjectIds.map(() => "?").join(", ");
-        db.prepare(`DELETE FROM notification_settings WHERE projectId IN (${projectPlaceholders})`).run(...ownedProjectIds);
-        db.prepare(`DELETE FROM schedules WHERE projectId IN (${projectPlaceholders})`).run(...ownedProjectIds);
-      }
-      db.prepare(`DELETE FROM activities WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
-      db.prepare(`DELETE FROM runs WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
-      db.prepare(`DELETE FROM tests WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
-      db.prepare(`DELETE FROM projects WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
-      db.prepare(`DELETE FROM workspace_members WHERE workspaceId IN (${placeholders})`).run(...ownedWorkspaceIds);
-      db.prepare(`DELETE FROM workspaces WHERE id IN (${placeholders})`).run(...ownedWorkspaceIds);
-    }
-
-    db.prepare("DELETE FROM workspace_members WHERE userId = ?").run(user.id);
-    db.prepare("DELETE FROM oauth_ids WHERE userId = ?").run(user.id);
-    db.prepare("DELETE FROM password_reset_tokens WHERE userId = ?").run(user.id);
-    db.prepare("DELETE FROM verification_tokens WHERE userId = ?").run(user.id);
-    db.prepare("DELETE FROM users WHERE id = ?").run(user.id);
-  });
-
   try {
-    removeAccount();
+    accountRepo.deleteAccount(user.id);
   } catch (err) {
     console.error(formatLogLine("error", null, `[auth/account] Delete failed for user ${user.id}: ${err.message}`));
     return res.status(500).json({ error: "Failed to delete account." });

--- a/backend/tests/account-compliance.test.js
+++ b/backend/tests/account-compliance.test.js
@@ -1,0 +1,142 @@
+/**
+ * @module tests/account-compliance
+ * @description Integration coverage for SEC-002, SEC-003, and FEA-001 API gaps.
+ */
+
+import assert from "node:assert/strict";
+import authRouter, { requireAuth } from "../src/routes/auth.js";
+import projectsRouter from "../src/routes/projects.js";
+import { app } from "../src/middleware/appSetup.js";
+import * as userRepo from "../src/database/repositories/userRepo.js";
+import * as projectRepo from "../src/database/repositories/projectRepo.js";
+import { createTestContext } from "./helpers/test-base.js";
+
+const t = createTestContext();
+const { req, workspaceScope } = t;
+
+let mounted = false;
+function mountRoutesOnce() {
+  if (mounted) return;
+  app.use("/api/auth", authRouter);
+  app.use("/api/projects", requireAuth, workspaceScope, projectsRouter);
+  mounted = true;
+}
+
+async function main() {
+  mountRoutesOnce();
+  t.resetDb();
+
+  const env = t.setupEnv({ SKIP_EMAIL_VERIFICATION: "true" });
+
+  const server = app.listen(0);
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+
+  try {
+    const email = `privacy-${Date.now()}@test.local`;
+    const password = "Password123!";
+
+    const { token } = await t.registerAndLogin(base, {
+      name: "Privacy User",
+      email,
+      password,
+    });
+
+    // SEC-002: CSP header should include nonce and avoid unsafe-inline scripts.
+    let out = await req(base, "/api/auth/me", { token });
+    assert.equal(out.res.status, 200);
+    const csp = out.res.headers.get("content-security-policy") || "";
+    assert.match(csp, /script-src[^;]*'nonce-[^']+'/, "CSP script-src should include a nonce");
+    assert.ok(!/script-src[^;]*'unsafe-inline'/.test(csp), "CSP script-src must not include unsafe-inline");
+
+    // Create one project so export + deletion have owned data to operate on.
+    out = await req(base, "/api/projects", {
+      method: "POST",
+      token,
+      body: { name: "Privacy App", url: "https://example.com" },
+    });
+    assert.equal(out.res.status, 201);
+    const projectId = out.json.id;
+
+    // FEA-001: notification settings CRUD + validation.
+    out = await req(base, `/api/projects/${projectId}/notifications`, {
+      method: "PATCH",
+      token,
+      body: { teamsWebhookUrl: "", emailRecipients: "", webhookUrl: "", enabled: true },
+    });
+    assert.equal(out.res.status, 400, "At least one channel is required");
+
+    out = await req(base, `/api/projects/${projectId}/notifications`, {
+      method: "PATCH",
+      token,
+      body: { teamsWebhookUrl: "https://teams.example/webhook", emailRecipients: "qa@example.com", enabled: true },
+    });
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.notifications.enabled, true);
+
+    out = await req(base, `/api/projects/${projectId}/notifications`, { token });
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.notifications.projectId, projectId);
+
+    out = await req(base, `/api/projects/${projectId}/notifications`, { method: "DELETE", token });
+    assert.equal(out.res.status, 200);
+
+    // SEC-003 export: requires password confirmation.
+    out = await fetch(`${base}/api/auth/export`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    }).then(async (res) => ({ res, json: await res.json().catch(() => ({})) }));
+    assert.equal(out.res.status, 400);
+
+    out = await fetch(`${base}/api/auth/export`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Account-Password": password,
+      },
+    }).then(async (res) => ({ res, json: await res.json().catch(() => ({})) }));
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.user.email, email);
+    assert.ok(Array.isArray(out.json.projects), "Export payload should include projects array");
+
+    // Recreate project to verify delete cascade on owned data.
+    out = await req(base, "/api/projects", {
+      method: "POST",
+      token,
+      body: { name: "Delete Me", url: "https://example.com/delete" },
+    });
+    assert.equal(out.res.status, 201);
+    const doomedProjectId = out.json.id;
+
+    // SEC-003 delete: wrong password fails, correct password succeeds.
+    out = await req(base, "/api/auth/account", {
+      method: "DELETE",
+      token,
+      body: { password: "WrongPass123!" },
+    });
+    assert.equal(out.res.status, 401);
+
+    out = await req(base, "/api/auth/account", {
+      method: "DELETE",
+      token,
+      body: { password },
+    });
+    assert.equal(out.res.status, 200);
+    assert.equal(out.json.ok, true);
+
+    const userAfterDelete = userRepo.getByEmail(email);
+    const projectAfterDelete = projectRepo.getById(doomedProjectId);
+    assert.equal(userAfterDelete, undefined, "User should be hard-deleted");
+    assert.equal(projectAfterDelete, undefined, "Owned project should be deleted with account");
+
+    console.log("✅ account-compliance: all checks passed");
+  } finally {
+    env.restore();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+main().catch((err) => {
+  console.error("❌ account-compliance failed:", err);
+  process.exit(1);
+});

--- a/backend/tests/account-compliance.test.js
+++ b/backend/tests/account-compliance.test.js
@@ -97,6 +97,7 @@ async function main() {
     }).then(async (res) => ({ res, json: await res.json().catch(() => ({})) }));
     assert.equal(out.res.status, 200);
     assert.equal(out.json.user.email, email);
+    assert.equal(out.json.user.passwordHash, undefined, "Export must not include passwordHash");
     assert.ok(Array.isArray(out.json.projects), "Export payload should include projects array");
 
     // Recreate project to verify delete cascade on owned data.
@@ -108,13 +109,13 @@ async function main() {
     assert.equal(out.res.status, 201);
     const doomedProjectId = out.json.id;
 
-    // SEC-003 delete: wrong password fails, correct password succeeds.
+    // SEC-003 delete: wrong password fails (403, not 401 — avoids logout redirect).
     out = await req(base, "/api/auth/account", {
       method: "DELETE",
       token,
       body: { password: "WrongPass123!" },
     });
-    assert.equal(out.res.status, 401);
+    assert.equal(out.res.status, 403);
 
     out = await req(base, "/api/auth/account", {
       method: "DELETE",

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -35,6 +35,7 @@ const files = [
   "tests/run-worker.test.js",
   "tests/abort-worker.test.js",
   "tests/email-verification.test.js",
+  "tests/account-compliance.test.js",
   "tests/postgres-adapter.test.js",
 ];
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DB**: Migration 004 — `notification_settings` table with per-project Teams webhook URL, email recipients, generic webhook URL, and enabled flag (FEA-001) (#92)
 - **Backend**: Failure notifications fire automatically on run completion (with failures) for all run types: manual, scheduled, CI/CD triggered, and BullMQ worker-processed (FEA-001) (#92)
 - **Frontend**: `api.getNotifications()`, `api.upsertNotifications()`, `api.deleteNotifications()` — notification settings API methods (FEA-001) (#92)
+- **API**: `GET /api/auth/export` — export all user-owned account data as JSON (workspaces, projects, tests, runs, activities, schedules, notification settings) for GDPR/CCPA data portability; requires password confirmation via `X-Account-Password` header (SEC-003) (#93)
+- **API**: `DELETE /api/auth/account` — hard-delete user account and all owned workspace data in a single transaction for GDPR right to erasure; requires password confirmation in request body (SEC-003) (#93)
+- **Backend**: `accountRepo.js` — repository module encapsulating account export and cascade deletion queries (SEC-003) (#93)
+- **Frontend**: Account tab in Settings with password-confirmed "Export account data" (JSON download) and "Delete account" (two-click confirm with 5s auto-disarm) actions (SEC-003) (#93)
+- **Frontend**: `api.exportAccountData(password)` and `api.deleteAccount(password)` client methods (SEC-003) (#93)
+
+### Security
+- **CSP**: Replaced `'unsafe-inline'` in `script-src` with per-request cryptographic nonce — generates `crypto.randomBytes(16)` nonce per request, passes it to Helmet CSP directive, and injects `nonce="__CSP_NONCE__"` placeholder on all `<script>` tags via Vite plugin; `serveIndexWithNonce()` replaces the placeholder at serve-time (SEC-002) (#93)
+- **Account**: Account export strips `passwordHash` from the user profile before including it in the JSON payload — prevents offline brute-force attacks if the export file is shared (SEC-003) (#93)
+- **Account**: Password confirmation failures on export/delete return 403 (not 401) to prevent the frontend from misinterpreting them as session expiry and triggering an unexpected logout redirect (SEC-003) (#93)
 
 ## [1.5.0] — 2026-04-17
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <!-- GitHub Pages SPA restore — pairs with public/404.html redirect -->
-    <script>
+    <script nonce="__CSP_NONCE__">
       (function(l) {
         if (l.search[1] === '/') {
           var decoded = l.search.slice(1).split('&').map(function(s) {
@@ -23,13 +23,13 @@
       }(window.location));
     </script>
     <!-- Theme: apply saved preference before first paint to prevent FOWT -->
-    <script>
+    <script nonce="__CSP_NONCE__">
       (function(){
         var t=localStorage.getItem('app_theme');
         if(t==='light'||t==='dark'){document.documentElement.setAttribute('data-theme',t);document.documentElement.style.colorScheme=t;}
       })();
     </script>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script nonce="__CSP_NONCE__" type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -29,8 +29,21 @@ server {
     proxy_set_header Host $host;
   }
 
-  # SPA fallback
+  # SPA fallback — proxy HTML page requests to the backend so it can inject
+  # the per-request CSP nonce into __CSP_NONCE__ placeholders (SEC-002).
+  # Static assets (JS, CSS, images, fonts) are still served directly by nginx
+  # via the try_files $uri check — only navigation requests that don't match
+  # a file on disk fall through to the backend.
   location / {
-    try_files $uri $uri/ /index.html;
+    try_files $uri $uri/ @backend_spa;
+  }
+
+  location @backend_spa {
+    proxy_pass http://backend:3001;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -389,9 +389,10 @@ export const api = {
       handleUnauthorized();
       throw new Error("Session expired. Please sign in again.");
     }
+    // 403 = wrong password confirmation — do NOT trigger logout redirect.
     if (!res.ok) {
       const err = await parseJsonResponse(res).catch(() => ({ error: res.statusText }));
-      throw new Error(`[${res.status}] ${err.error || res.statusText || "Request failed"}`);
+      throw new Error(err.error || res.statusText || "Request failed");
     }
     return parseJsonResponse(res);
   },

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -370,6 +370,38 @@ export const api = {
    */
   resendVerification: (email) => req("POST", "/auth/resend-verification", { email }),
 
+  // ── Account data portability / deletion (SEC-003) ───────────────────────────
+  /**
+   * Export account data as JSON. Password confirmation is required.
+   * @param {string} password
+   * @returns {Promise<Object>}
+   */
+  exportAccountData: async (password) => {
+    const res = await fetch(`${BASE}/auth/export`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Account-Password": password,
+      },
+      credentials: "include",
+    });
+    if (res.status === 401) {
+      handleUnauthorized();
+      throw new Error("Session expired. Please sign in again.");
+    }
+    if (!res.ok) {
+      const err = await parseJsonResponse(res).catch(() => ({ error: res.statusText }));
+      throw new Error(`[${res.status}] ${err.error || res.statusText || "Request failed"}`);
+    }
+    return parseJsonResponse(res);
+  },
+  /**
+   * Delete user account and owned data. Password confirmation is required.
+   * @param {string} password
+   * @returns {Promise<{ok: boolean, message: string}>}
+   */
+  deleteAccount: (password) => req("DELETE", "/auth/account", { password }),
+
   // ── Workspace & Members (ACL-001, ACL-002) ───────────────────────────────────
   /** @returns {Promise<Object>} Current workspace details. */
   getWorkspace:      ()              => req("GET",    "/workspaces/current"),

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -525,6 +525,7 @@ const SETTINGS_TABS = [
   { key: "providers",   label: "AI Providers",  icon: <Zap size={14} /> },
   { key: "members",     label: "Members",       icon: <Users size={14} /> },
   { key: "execution",   label: "Execution",     icon: <Cpu size={14} /> },
+  { key: "account",     label: "Account",       icon: <Shield size={14} /> },
   { key: "data",        label: "Data",          icon: <Database size={14} /> },
   { key: "recycle-bin", label: "Recycle Bin",   icon: <Trash2 size={14} /> },
   { key: "system",      label: "System",        icon: <Server size={14} /> },
@@ -928,6 +929,94 @@ function RecycleBinTab() {
   );
 }
 
+function AccountTab() {
+  const { logout } = useAuth();
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  async function handleExport() {
+    if (!password.trim()) {
+      setStatus({ type: "err", text: "Enter your password to export account data." });
+      return;
+    }
+    setBusy(true);
+    setStatus(null);
+    try {
+      const data = await api.exportAccountData(password.trim());
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = `sentri-account-export-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(() => { URL.revokeObjectURL(a.href); a.remove(); }, 100);
+      setStatus({ type: "ok", text: "Account export downloaded." });
+    } catch (err) {
+      setStatus({ type: "err", text: err.message || "Export failed." });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!password.trim()) {
+      setStatus({ type: "err", text: "Enter your password to delete your account." });
+      return;
+    }
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      setTimeout(() => setConfirmDelete(false), 5000);
+      return;
+    }
+    setBusy(true);
+    setStatus(null);
+    try {
+      await api.deleteAccount(password.trim());
+      await logout();
+    } catch (err) {
+      setStatus({ type: "err", text: err.message || "Account deletion failed." });
+    } finally {
+      setBusy(false);
+      setConfirmDelete(false);
+    }
+  }
+
+  return (
+    <div className="flex-col gap-lg">
+      <SectionTitle icon={<Shield size={16} color="var(--red)" />} title="Account & Privacy" sub="Export your data or permanently delete your account." />
+      <div className="card card-padded flex-col gap-md">
+        <label className="text-sm font-semi">
+          Confirm password
+          <input
+            className="input"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Enter your current password"
+            style={{ marginTop: 8 }}
+          />
+        </label>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <button className="btn btn-ghost btn-sm" disabled={busy} onClick={handleExport}>
+            {busy ? <RefreshCw size={13} className="spin" /> : <ExternalLink size={13} />} Export account data
+          </button>
+          <button className={`btn btn-sm ${confirmDelete ? "btn-danger" : "btn-ghost"}`} disabled={busy} onClick={handleDelete}>
+            {busy ? <RefreshCw size={13} className="spin" /> : <Trash2 size={13} />}
+            {confirmDelete ? "Confirm delete account" : "Delete account"}
+          </button>
+        </div>
+        {status && (
+          <div className={status.type === "ok" ? "st-status-ok" : "st-status-err"}>
+            {status.type === "ok" ? <Check size={12} /> : <AlertCircle size={12} />} {status.text}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function Settings() {
   usePageTitle("Settings");
   const navigate = useNavigate();
@@ -1084,6 +1173,9 @@ export default function Settings() {
         These values are compiled into the self-healing runtime. To customise, edit <span className="text-mono" style={{ background: "var(--bg3)", padding: "1px 5px", borderRadius: 3 }}>backend/src/selfHealing.js</span>
       </div>
       </>}
+
+      {/* ── Tab: Account ── */}
+      {tab === "account" && <AccountTab />}
 
       {/* ── Tab: Data ── */}
       {tab === "data" && <>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+function cspNoncePlugin() {
+  return {
+    name: "sentri-csp-nonce",
+    transformIndexHtml(html) {
+      return html.replace(/<script(?![^>]*\bnonce=)/g, '<script nonce="__CSP_NONCE__"');
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), cspNoncePlugin()],
   base: process.env.GITHUB_PAGES === "true" ? "/sentri/" : "/",
 
   build: {


### PR DESCRIPTION
### Motivation
- Close security gaps SEC-002 by removing `'unsafe-inline'` for scripts and enable nonce-based CSP to mitigate XSS risk. 
- Implement SEC-003 to provide GDPR/CCPA-compliant account data export and secure account deletion. 
- Cover INF-003 → FEA-001 testing gaps by adding integration tests for notification settings and the new account/privacy flows. 

### Description
- Backend CSP: generate a per-request nonce via `crypto.randomBytes(16)` and expose it on `res.locals.cspNonce` and the `X-CSP-Nonce` header, and update Helmet `contentSecurityPolicy` to use a `'nonce-<value>'` `scriptSrc` instead of `'unsafe-inline'` (`backend/src/middleware/appSetup.js`).
- Frontend CSP plumbing: add a Vite `transformIndexHtml` plugin to inject `nonce="__CSP_NONCE__"` into `<script>` tags and add nonce placeholders in `frontend/index.html` to align with the backend nonce (`frontend/vite.config.js`, `frontend/index.html`).
- Account export & deletion (SEC-003): add `GET /api/auth/export` and `DELETE /api/auth/account` endpoints that require password confirmation, produce a JSON export of all user-owned workspace data, and perform transactional hard-deletion of owned workspaces/projects/data (`backend/src/routes/auth.js`).
- Frontend account UX & API: add `api.exportAccountData(password)` and `api.deleteAccount(password)` client calls and an Account tab in `Settings` with password-confirmed “Export account data” and “Delete account” actions and a confirm flow (`frontend/src/api.js`, `frontend/src/pages/Settings.jsx`).
- Tests: add integration test `backend/tests/account-compliance.test.js` covering CSP nonce presence, notification settings CRUD/validation (FEA-001), and SEC-003 export/delete flows, and register it in the unified `backend/tests/run-tests.js` test runner.

### Testing
- Syntax checks: ran `node --check` on updated server and JS config files (`backend/src/routes/auth.js`, `backend/src/middleware/appSetup.js`, `frontend/src/api.js`, `frontend/vite.config.js`) and they passed successfully. 
- Integration test added: `backend/tests/account-compliance.test.js` was created and registered in `backend/tests/run-tests.js` (intended to run via the repository test runner). 
- Attempted to run the new integration test directly (`node tests/account-compliance.test.js`) but the execution failed in this environment due to missing runtime dependencies (error: `ERR_MODULE_NOT_FOUND: Cannot find package 'express'`), so full automated test execution was not completed here; the test file is present and should pass in CI after `npm install`/standard test setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3092bc9808326a856475950e19362)