### PR TITLE
Start FEA-002: introduce TanStack Query provider and migrate useProjectData

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,11 +9,12 @@
     "test": "node tests/run-tests.js"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.66.9",
+    "lucide-react": "^0.577.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.5",
-    "recharts": "^2.15.0",
-    "lucide-react": "^0.577.0"
+    "recharts": "^2.15.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/src/hooks/useProjectData.js
+++ b/frontend/src/hooks/useProjectData.js
@@ -1,47 +1,71 @@
 /**
  * @module hooks/useProjectData
- * @description Shared data-fetching hook with 30-second TTL cache.
- *
- * Fetches projects, tests, and runs in parallel. The module-level cache
- * survives component unmount/remount so navigating Projects → Tests → Projects
- * doesn't refetch everything.
- *
- * ### Exports
- * - {@link useProjectData} (default) — The hook itself.
- * - {@link invalidateProjectDataCache} — Bust the cache after mutations.
+ * @description Shared TanStack Query hook for projects, tests, and runs.
  */
 
-import { useEffect, useState, useMemo, useRef } from "react";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "../api";
+import { queryClient, projectDataQueryKeys } from "../queryClient";
 
-// module-level cache with 30s TTL — survives component unmount/remount
-const CACHE_TTL = 30_000;
-const cache = {
-  projects:  { data: null, ts: 0 },
-  runs:      { data: null, ts: 0 },
-  tests:     { data: null, ts: 0 },
-};
-
-function isFresh(entry) {
-  return entry.data !== null && Date.now() - entry.ts < CACHE_TTL;
-}
-
-function setCache(key, data) {
-  cache[key] = { data, ts: Date.now() };
-}
+const STALE_TIME_MS = 30_000;
 
 /**
- * Bust the project data cache. Call after mutations (create/delete project,
+ * Bust cached project data queries. Call after mutations (create/delete project,
  * approve/reject tests, etc.) so the next render fetches fresh data.
+ *
+ * @returns {void}
  */
 export function invalidateProjectDataCache() {
-  cache.projects.ts = 0;
-  cache.runs.ts     = 0;
-  cache.tests.ts    = 0;
+  queryClient.invalidateQueries({ queryKey: projectDataQueryKeys.root });
 }
 
 /**
- * Shared hook that fetches projects, tests, and runs in parallel with caching.
+ * Fetch all runs for the provided projects and enrich them for UI use.
+ *
+ * @param {Array<{ id: string, name: string, url: string }>} projects - Project list.
+ * @returns {Promise<Array>} Enriched run list sorted newest-first.
+ */
+async function fetchProjectRuns(projects) {
+  const allRuns = await Promise.all(
+    projects.map((project) =>
+      api.getRuns(project.id)
+        .then((runs) =>
+          runs.map((run) => ({
+            ...run,
+            projectId: project.id,
+            projectName: project.name,
+            projectUrl: project.url,
+          }))
+        )
+        .catch(() => [])
+    )
+  );
+
+  return allRuns
+    .flat()
+    .sort((a, b) => new Date(b.startedAt) - new Date(a.startedAt));
+}
+
+/**
+ * Fetch tests with batch endpoint fallback to per-project endpoint.
+ *
+ * @param {Array<{ id: string }>} projects - Project list.
+ * @returns {Promise<Array>} Flattened tests.
+ */
+async function fetchProjectTests(projects) {
+  try {
+    return await api.getAllTests();
+  } catch {
+    const testsByProject = await Promise.all(
+      projects.map((project) => api.getTests(project.id).catch(() => []))
+    );
+    return testsByProject.flat();
+  }
+}
+
+/**
+ * Shared hook that fetches projects, tests, and runs in parallel with query caching.
  *
  * @param {Object}  [options]
  * @param {boolean} [options.fetchTests=true] - Also fetch tests per project.
@@ -55,119 +79,63 @@ export function invalidateProjectDataCache() {
  * @property {Array}   testRuns  - `allRuns` filtered to `type === "test_run"`.
  * @property {Object}  projMap   - `{ [projectId]: projectName }`.
  * @property {boolean} loading   - `true` while initial fetch is in progress.
- * @property {Function} refresh  - Call to force a fresh fetch (busts cache).
+ * @property {Function} refresh  - Call to force a fresh fetch.
  */
 export default function useProjectData({ fetchTests = true, fetchRuns = true } = {}) {
-  const [projects, setProjects] = useState(() => cache.projects.data || []);
-  const [allTests, setAllTests] = useState(() => cache.tests.data   || []);
-  const [allRuns,  setAllRuns]  = useState(() => cache.runs.data    || []);
-  // Start as not-loading if we already have fresh cache data
-  const [loading, setLoading]   = useState(
-    !isFresh(cache.projects) ||
-    (fetchRuns  && !isFresh(cache.runs))  ||
-    (fetchTests && !isFresh(cache.tests))
-  );
-  const mountedRef = useRef(true);
+  const projectsQuery = useQuery({
+    queryKey: projectDataQueryKeys.projects,
+    queryFn: api.getProjects,
+    staleTime: STALE_TIME_MS,
+    gcTime: STALE_TIME_MS,
+    retry: 1,
+  });
 
-  async function load(bust = false) {
-    if (bust) invalidateProjectDataCache();
+  const projects = projectsQuery.data || [];
 
-    try {
-      // Projects
-      let projs;
-      if (!bust && isFresh(cache.projects)) {
-        projs = cache.projects.data;
-      } else {
-        projs = await api.getProjects();
-        setCache("projects", projs);
-      }
-      if (mountedRef.current) setProjects(projs);
+  const runsQuery = useQuery({
+    queryKey: projectDataQueryKeys.runs,
+    queryFn: () => fetchProjectRuns(projects),
+    enabled: fetchRuns && projects.length > 0,
+    staleTime: STALE_TIME_MS,
+    gcTime: STALE_TIME_MS,
+    retry: 1,
+  });
 
-      const promises = [];
+  const testsQuery = useQuery({
+    queryKey: projectDataQueryKeys.tests,
+    queryFn: () => fetchProjectTests(projects),
+    enabled: fetchTests && projects.length > 0,
+    staleTime: STALE_TIME_MS,
+    gcTime: STALE_TIME_MS,
+    retry: 1,
+  });
 
-      // Runs
-      if (fetchRuns) {
-        if (!bust && isFresh(cache.runs)) {
-          promises.push(Promise.resolve(cache.runs.data));
-        } else {
-          promises.push(
-            Promise.all(
-              projs.map(p =>
-                api.getRuns(p.id)
-                  .then(rs => rs.map(r => ({ ...r, projectId: p.id, projectName: p.name, projectUrl: p.url })))
-                  .catch(() => [])
-              )
-            ).then(r => {
-              const flat = r.flat().sort((a, b) => new Date(b.startedAt) - new Date(a.startedAt));
-              setCache("runs", flat);
-              return flat;
-            })
-          );
-        }
-      } else {
-        // Preserve cached data when not fetching — don't overwrite state with []
-        promises.push(Promise.resolve(cache.runs.data || []));
-      }
-
-      // Tests — try batch endpoint first (Fix #26), fall back to per-project
-      if (fetchTests) {
-        if (!bust && isFresh(cache.tests)) {
-          promises.push(Promise.resolve(cache.tests.data));
-        } else {
-          promises.push(
-            api.getAllTests()
-              .catch(() =>
-                Promise.all(projs.map(p => api.getTests(p.id).catch(() => []))).then(t => t.flat())
-              )
-              .then(tests => {
-                setCache("tests", tests);
-                return tests;
-              })
-          );
-        }
-      } else {
-        // Preserve cached data when not fetching — don't overwrite state with []
-        promises.push(Promise.resolve(cache.tests.data || []));
-      }
-
-      const [runs, tests] = await Promise.all(promises);
-      if (mountedRef.current) {
-        setAllRuns(runs);
-        setAllTests(tests);
-      }
-    } catch (err) {
-      console.error("useProjectData load error:", err);
-    } finally {
-      if (mountedRef.current) setLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    mountedRef.current = true;
-    const needsFetch =
-      !isFresh(cache.projects) ||
-      (fetchRuns  && !isFresh(cache.runs))  ||
-      (fetchTests && !isFresh(cache.tests));
-
-    if (needsFetch) {
-      setLoading(true);
-      load();
-    }
-    return () => { mountedRef.current = false; };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const allRuns = fetchRuns ? (runsQuery.data || []) : [];
+  const allTests = fetchTests ? (testsQuery.data || []) : [];
 
   const projMap = useMemo(
-    () => Object.fromEntries(projects.map(p => [p.id, p.name])),
+    () => Object.fromEntries(projects.map((project) => [project.id, project.name])),
     [projects]
   );
 
   const testRuns = useMemo(
-    () => allRuns.filter(r => r.type === "test_run"),
+    () => allRuns.filter((run) => run.type === "test_run"),
     [allRuns]
   );
 
+  const loading = Boolean(
+    projectsQuery.isLoading ||
+    (fetchRuns && runsQuery.isLoading) ||
+    (fetchTests && testsQuery.isLoading)
+  );
+
   return {
-    projects, allTests, allRuns, testRuns, projMap, loading,
-    refresh: () => { setLoading(true); load(true); },
+    projects,
+    allTests,
+    allRuns,
+    testRuns,
+    projMap,
+    loading,
+    refresh: () => invalidateProjectDataCache(),
   };
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.jsx";
+import { queryClient } from "./queryClient";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend/src/queryClient.js
+++ b/frontend/src/queryClient.js
@@ -1,0 +1,22 @@
+/**
+ * @module queryClient
+ * @description Shared TanStack Query client and query keys.
+ */
+
+import { QueryClient } from "@tanstack/react-query";
+
+export const projectDataQueryKeys = {
+  root: ["projectData"],
+  projects: ["projectData", "projects"],
+  runs: ["projectData", "runs"],
+  tests: ["projectData", "tests"],
+};
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});


### PR DESCRIPTION
### Motivation
- Begin roadmap item `FEA-002` to replace ad-hoc `useEffect`/`useState` fetch patterns with a centralized TanStack Query data layer for better caching, background refresh, and simpler invalidation. 
- Migrate the shared project-data hook first to provide an immediate global cache and invalidate API for existing callers. 

### Description
- Added `@tanstack/react-query` to `frontend/package.json` and introduced a shared Query client in `frontend/src/queryClient.js` with query keys for project data. 
- Wrapped the app in `QueryClientProvider` by updating `frontend/src/main.jsx` so hooks can share the query cache. 
- Refactored `frontend/src/hooks/useProjectData.js` to use `useQuery` for `projects`, `runs`, and `tests`, preserved 30s cache behavior via `staleTime`/`gcTime`, and retained the public API (`projects`, `allTests`, `allRuns`, `testRuns`, `projMap`, `loading`, `refresh`). 
- Implemented `invalidateProjectDataCache()` backed by `queryClient.invalidateQueries()` so existing callers and `refresh()` continue to work without changing call sites. 

### Testing
- Ran frontend unit/integration tests with `npm --prefix frontend run test` and all tests passed. 
- Attempted to install `@tanstack/react-query` in this environment (`npm install ...`), but `npm` returned 403 from the registry so the package could not be installed. 
- Because the dependency installation failed, `npm --prefix frontend run build` / `vite build` failed locally since Vite could not resolve `@tanstack/react-query` (build failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec25e41f9c8326af0800b1034c93e6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rameshbabuprudhvi/sentri/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
