### PR TITLE
docs(qa): add UI-first test-shape contract and section index for agents — covers both themes (UI-first framing + new YAML/intent navigation).

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: 🐛 Bug report
+description: Report a reproducible defect in Sentri (frontend, backend, or deployed app).
+title: "bug: <short description>"
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Before submitting, please:
+        - Search [existing issues](../issues?q=is%3Aissue) to avoid duplicates.
+        - Confirm the bug reproduces on the latest `main`.
+        - For security issues, **do not** open a public issue — see `SECURITY.md` (or email the maintainer).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I can reproduce this on the latest `main` (or a deployed build I can identify below).
+          required: true
+        - label: This is not a security vulnerability (those go to `SECURITY.md`).
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence describing the bug.
+      placeholder: "Login form submits empty payload when password manager autofills."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, numbered steps. Include test data if relevant.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error messages, console output, stack traces, or screenshots.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      multiple: true
+      options:
+        - Frontend (UI)
+        - Backend (API)
+        - Authentication / permissions
+        - Recorder
+        - Crawl / test generation
+        - Runs / scheduling
+        - AI Fix / AI Chat
+        - Visual testing
+        - Reports / dashboard
+        - Docs
+        - CI / build
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical (data loss, auth bypass, total outage)
+        - High (core flow broken, no workaround)
+        - Medium (feature broken, workaround exists)
+        - Low (cosmetic / minor)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Sentri version / commit
+      description: Git SHA, release tag, or "deployed at <url>".
+      placeholder: "main @ a1b2c3d  /  https://rameshbabuprudhvi.github.io/sentri"
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Browser + version, OS, Node version (if running locally).
+      placeholder: |
+        - Browser: Chrome 130 / Firefox 131 / Safari 18
+        - OS: macOS 14.5 / Windows 11 / Ubuntu 24.04
+        - Node: 20.x (only if running locally)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots / network traces
+      description: Paste relevant logs, attach screenshots, or link a HAR file. Redact secrets.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help — recent changes, related issues, hypotheses.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation & QA guide
+    url: https://github.com/rameshbabuprudhvi/sentri/blob/main/QA.md
+    about: Check QA.md, README.md, and ROADMAP.md before opening an issue.
+  - name: 💬 Questions & discussions
+    url: https://github.com/rameshbabuprudhvi/sentri/discussions
+    about: Use Discussions for usage questions, ideas, and Q&A (not bug reports).
+  - name: 🔒 Security vulnerabilities
+    url: https://github.com/rameshbabuprudhvi/sentri/security/advisories/new
+    about: Report security issues privately — do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: ✨ Feature request
+description: Suggest a new capability or enhancement for Sentri.
+title: "feat: <short description>"
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Per `REVIEW.md`, new features generally need to exist in `ROADMAP.md` before a PR is accepted.
+        Use this template to propose the idea so it can be discussed and (if accepted) added to the roadmap.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I have read `ROADMAP.md` and this is not already planned.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / user need
+      description: What problem does this solve? Who is affected?
+      placeholder: "As a <role>, I want <capability> so that <outcome>."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should it work? Include UX sketches, API shape, or example flows.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated and why this one is preferred.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      multiple: true
+      options:
+        - Frontend (UI)
+        - Backend (API)
+        - Authentication / permissions
+        - Recorder
+        - Crawl / test generation
+        - Runs / scheduling
+        - AI Fix / AI Chat
+        - Visual testing
+        - Reports / dashboard
+        - Docs
+        - CI / build
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Bullet list of testable conditions for "done".
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, prior art, screenshots, related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,60 @@
-## What does this PR do?
+## Summary
 
-<!-- One paragraph. What problem does it solve, and how? -->
+<!-- One paragraph. What does this PR change, at a high level? -->
+
+## Motivation / Context
+
+<!-- Why is this change needed? Link prior discussion, design docs, or incidents. -->
 
 ## Linked issue
 
 Closes #<!-- issue number — PRs without a linked issue for non-trivial changes are closed -->
 
+<!-- Depends on: #<PR-number> (delete if not applicable) -->
+
 ## Type of change
 
-- [ ] Bug fix
-- [ ] New feature (exists in ROADMAP.md)
-- [ ] Refactor / performance improvement
-- [ ] Documentation / tests only
+<!-- Tick all that apply. Aligns with Conventional Commits: https://www.conventionalcommits.org/ -->
+
+- [ ] Bug fix (`fix:`)
+- [ ] New feature (`feat:`, exists in ROADMAP.md)
+- [ ] Breaking change (API, schema, or behavior incompatible with prior versions)
+- [ ] Refactor / performance improvement (`refactor:` / `perf:`)
+- [ ] Documentation / tests only (`docs:` / `test:`)
+- [ ] Build / CI / chore (`build:` / `ci:` / `chore:`)
+- [ ] Security fix
+
+## How to test
+
+<!-- Step-by-step instructions a reviewer can follow to verify this works. -->
+
+1. <!-- step -->
+2. <!-- step -->
+3. <!-- step -->
+
+## Screenshots / recordings (if UI changed)
+
+<!-- Delete this section if not applicable. Provide before/after for visual changes. -->
+
+| Before | After |
+| --- | --- |
+|        |       |
+
+<!-- For interaction changes, attach a short screen recording (GIF / Loom). -->
+
+## Risk & rollback
+
+<!-- What's the blast radius if this goes wrong? How do we roll back? Delete if trivial. -->
+
+## Reviewer notes
+
+<!-- Optional: areas you'd like extra scrutiny on, known gaps, follow-ups. -->
 
 ## Checklist
 
-- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `perf:`, `docs:`, etc.)
+<!-- Unchecked items are fine if they don't apply — leave a note explaining why. -->
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `perf:`, `docs:`, `refactor:`, `chore:`, etc.)
 - [ ] Branch is off `develop`, not `main`
 - [ ] `cd backend && npm test` passes locally
 - [ ] `cd frontend && npm run build && npm test` passes locally
@@ -24,16 +63,5 @@ Closes #<!-- issue number — PRs without a linked issue for non-trivial changes
 - [ ] `QA.md` walked for affected flows; Golden E2E re-run if core flow was touched
 - [ ] `permissions.json` updated if a `requireRole()` gate was added/changed
 - [ ] ROADMAP.md + NEXT.md updated if this closes a roadmap item (see REVIEW.md)
+- [ ] UI changes meet accessibility requirements (keyboard nav, ARIA roles, color contrast)
 - [ ] No secrets, API keys, or credentials in the diff
-
-## How to test
-
-<!-- Step-by-step instructions a reviewer can follow to verify this works. -->
-
-1. 
-2. 
-3. 
-
-## Screenshots (if UI changed)
-
-<!-- Delete this section if not applicable -->

--- a/.github/PULL_REQUEST_TEMPLATE/qa-live-run.md
+++ b/.github/PULL_REQUEST_TEMPLATE/qa-live-run.md
@@ -1,0 +1,54 @@
+# QA Live Browser Run
+
+> Use this template for PRs that record a live browser QA run of the deployed
+> Sentri driven from `QA.md`. Pair with `qa-run-issues.md` at repo root.
+
+## Summary
+
+- **Run date:** `YYYY-MM-DD`
+- **Target URL:** `https://rameshbabuprudhvi.github.io/sentri`
+- **QA.md commit at run time:** `<sha>`
+- **Issues found:** `<N>` (`<blockers>` blocker / `<major>` major / `<minor>` minor)
+- **Issues fixed in this PR:** `<N>`
+- **Issues deferred to follow-up:** `<N>` — see `qa-run-issues.md`
+
+## Flow progress
+
+- [ ] Authentication (`QA.md` 353–376)
+- [ ] Workspaces (379–395)
+- [ ] Projects (399–414)
+- [ ] Tests Page — UI generation §3 (418–453)
+- [ ] Recorder (457–475)
+- [ ] Runs (478–501)
+- [ ] AI Fix (504–527)
+- [ ] Golden E2E Happy Path (240–339)
+
+Mark a box only when the flow has either a passing UI test on the deployed URL
+**or** a logged entry in `qa-run-issues.md`.
+
+## QA.md doc fixes included
+
+- [ ] `QA.md:27` anchor `#canonical-ui-test-shape--emit-this-by-default` resolves (heading promoted, or anchor dropped)
+- [ ] `QA.md:38` vs `QA.md:83` bug-template line range matches (`1048–1081` in both)
+- [ ] Emoji anchors in intent map (`QA.md:31-37`) verified on rendered GitHub, broken ones replaced with line ranges
+
+## Generated tests
+
+- [ ] All new tests follow the canonical UI shape at `QA.md:94-108`
+  - `page.goto(...)`, role selectors, `safeClick` / `safeFill`, ≥ 3 `expect(page....)` assertions
+- [ ] No `request.fetch` / `request.get` / `request.post` calls (unless the flow is explicitly an API test)
+- [ ] Tests live under the repo's existing Playwright test path (confirm before creating new dirs)
+
+## Mid-session resumability
+
+- [ ] Last commit pushed; no local-only changes
+- [ ] PR description "Flow progress" reflects actual state
+- [ ] `qa-run-issues.md` summary table sorted by severity
+- [ ] Resume note in latest PR comment: last-completed step + next step
+
+## Standard checklist
+
+- [ ] PR title follows Conventional Commits (`qa:` or `docs(qa):`)
+- [ ] Branch is off `develop`, not `main`
+- [ ] CI green
+- [ ] No secrets, API keys, or credentials in the diff

--- a/AGENT.md
+++ b/AGENT.md
@@ -45,6 +45,32 @@ If any of these pre-flight checks fails or is unclear, stop and ask the human be
 
 ---
 
+## Branch co-ownership protocol — applies to every agent and human on the PR
+
+This protocol is **agent-agnostic**. It applies equally to Devin, Claude Code, Codex, Cursor, Copilot Workspace, any future agent, and any human teammate sharing the branch. Wherever this document says "agent", substitute your own identity (`devin`, `claude`, `codex`, `cursor`, `copilot`, `human:<github-handle>`, etc.). This is what lets short prompts like *"Implement the current PR per NEXT.md"* be safe by default.
+
+**Your agent id** = the first token you put in every claim / heartbeat / hand-off comment. Pick one and stick with it for the whole session:
+- `devin` — Devin cloud agent
+- `claude` — Claude Code / Anthropic CLI
+- `codex` — OpenAI Codex CLI / ChatGPT code
+- `cursor` — Cursor background agent
+- `copilot` — GitHub Copilot Workspace
+- `human:<handle>` — a person editing directly
+
+### Rules
+
+1. **Lane = `agent-scope` field in `NEXT.md`.** You may only edit files listed under the current item's `agent-scope`. Files under `human-scope` are off-limits even if you "need" to touch them — comment on the PR instead. If the item lists multiple agent lanes (e.g. `agent-scope-backend`, `agent-scope-frontend`), pick one and name it in your claim.
+2. **Claim before first edit.** Push an empty commit `chore(claim): <agent-id> working on <files>` and post a PR comment `🟢 <agent-id>-active <UTC timestamp> — files: <list>`. If **any** `🟢 <other>-active` comment exists newer than yours and overlaps your files, stop and wait or pick a non-overlapping subset.
+3. **Re-sync before every commit.** `git fetch && git rebase origin/<branch>`. If the rebase touches a file outside your lane, abort, comment `⚠️ <agent-id> scope conflict on <file>`, and stop.
+4. **Commit-before-pause (mandatory).** Before any sleep, context switch, or long-running task: `git add -A && git commit -m "wip(<scope>): <what>, next: <what>" && git push`. Then post a PR comment with: agent-id, last-done, next-step, files-touched, files-not-yet-touched. **Never end a session with uncommitted local changes.**
+5. **Heartbeat.** Push a wip commit roughly every 15 min of active work. If you cannot make progress in 10 min, stop and comment instead of guessing.
+6. **Hand-off.** When your scope is done, post `✅ <agent-id>-done <files>` and stop. Do not start the next `NEXT.md` item without re-prompting.
+7. **Conflict de-escalation.** If a commit from another agent or a human lands on files in your lane while you were paused, treat the newer version as canonical, rebase onto it, re-run tests, continue. Do not revert. If unsure, stop and ask in a PR comment.
+
+If `NEXT.md` for the current item has no `agent-scope` field, treat the "Files to change" table as your scope and ask the human to confirm in a PR comment before your first edit.
+
+---
+
 ## Project Overview
 
 Sentri is a full-lifecycle AI QA platform that crawls a web application, generates Playwright test suites with an LLM, routes every generated test through a human-approval queue, executes approved tests against a live browser, and self-heals broken selectors across runs.

--- a/AGENT.md
+++ b/AGENT.md
@@ -13,6 +13,7 @@
 | Writing or modifying code | [STANDARDS.md](./STANDARDS.md) |
 | Looking up a utility, CSS class, hook, repo, env var, or auth strategy | [REFERENCE.md](./REFERENCE.md) — Ctrl+F only, never top-to-bottom |
 | Before opening a PR | [REVIEW.md](./REVIEW.md) |
+| First-time or external contributor (workflow, branch naming, commit style) | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 | Validating a user-visible change manually | [QA.md](./QA.md) — Golden E2E happy path + per-feature checks |
 | Looking up the role required for an endpoint | [`backend/src/middleware/permissions.json`](./backend/src/middleware/permissions.json) — machine-readable, lives next to `requireRole.js` |
 

--- a/NEXT.md
+++ b/NEXT.md
@@ -32,6 +32,12 @@ The zip must contain:
 | `backend/src/routes/tests.js` | Add `GET /api/v1/projects/:id/export/playwright` — fetch approved tests, call builder, stream zip |
 | `frontend/src/pages/Tests.jsx` | Add "Export as Playwright project" button that triggers a file download |
 
+### Lanes (for AGENT.md § Branch co-ownership protocol)
+
+- **agent-scope:** `backend/src/utils/exportFormats.js`, `backend/src/routes/tests.js`, `backend/tests/**` (new tests for the endpoint + builder) — claimable by any single agent (devin / claude / codex / cursor / copilot)
+- **human-scope:** `frontend/src/pages/Tests.jsx` and any other `frontend/**` change
+- **shared (coordinate via PR comment before editing):** `docs/changelog.md`, `ROADMAP.md`, this file
+
 ### Acceptance criteria
 
 - [ ] `GET /api/v1/projects/:id/export/playwright` returns `Content-Type: application/zip`

--- a/QA.md
+++ b/QA.md
@@ -15,16 +15,76 @@ It has two layers:
 
 ## 🤖 For agents — read this first
 
-This file is ~1000 lines. **Do not read it top-to-bottom.** Jump to the section you need.
+This file is ~1000 lines. **Do not read it top-to-bottom.** Use the index below to jump directly to the section you need, read only that section, then stop.
 
-| If you need… | Go to |
-|---|---|
-| Role required for any endpoint | [`backend/src/middleware/permissions.json`](./backend/src/middleware/permissions.json) (machine-readable, lives next to `requireRole.js`) |
-| End-to-end happy-path validation | [Golden E2E Happy Path](#golden-e2e-happy-path-must-pass-before-release) (50 steps) |
-| Per-feature checks | jump to `### <feature>` (Authentication, Workspaces, Projects, Tests Page, Recorder, Runs, AI Fix, Test Code Editing, Automation, Visual Testing, Dashboard, AI Chat, Settings, Account / GDPR, Email Verification, Recycle Bin, Audit Log, Notifications, Security, Reports, System Diagnostics, New Project, Runs List, Project Detail, Bulk Actions, Modals, Imports, Onboarding, Demo Mode, Workspace Switcher) |
-| Bug template | [Bug Reporting Template](#-bug-reporting-template) |
-| What's in / out of scope | [Coverage Checklist](#-coverage-checklist) and `backend/src/middleware/permissions.json#outOfScope` |
-| Generating tests for the deployed app | [Tests Page → UI / browser test generation](#-tests-page) — **UI tests are the default output**; API tests are additional |
+### Intent → section map
+
+If the user asks for… read only this section:
+
+| User intent | Section (anchor) | Lines |
+|---|---|---|
+| "Run / write all happy paths" | [Golden E2E Happy Path](#-golden-e2e-happy-path-must-pass-before-release) | 180–279 |
+| "Write Playwright tests for the deployed app" | [Canonical UI test shape](#canonical-ui-test-shape--emit-this-by-default) + [Tests Page §3](#-tests-page) | 34–48, 358–394 |
+| "Write an API test" | [Tests Page §4](#-tests-page) + [API Test Imports](#-api-test-imports-openapi-har-plain-english-api) | 358–394, 866–882 |
+| "Fix a failing test" | [AI Fix](#-ai-fix-failed-test-recovery) | 444–467 |
+| "Record a test" | [Recorder](#-recorder) | 397–415 |
+| "Run tests / regression" | [Runs](#%EF%B8%8F-runs) | 418–441 |
+| "Edit test code / steps" | [Test Code Editing](#%EF%B8%8F-test-code-editing-steps--source) | 470–499 |
+| "Schedule / trigger from CI" | [Automation](#-automation-cicd--scheduled-runs) | 502–526 |
+| "Visual / screenshot testing" | [Visual Testing](#%EF%B8%8F-visual-testing) | 529–546 |
+| "Verify permissions" | [`permissions.json`](./backend/src/middleware/permissions.json) **(canonical, read this, not prose)** | — |
+| "Verify security / authorization" | [Security](#-security) | 706–733 |
+| "Bulk actions / keyboard shortcuts" | [Bulk Actions](#%EF%B8%8F-bulk-actions--keyboard-shortcuts) | 813–841 |
+| "Report a bug" | [Bug Reporting Template](#-bug-reporting-template) | 988–1021 |
+
+### Section index (line ranges, for `sed -n 'A,Bp'` / partial reads)
+
+```yaml
+# Feature sections
+authentication:      { lines: 293-316 }
+workspaces:          { lines: 319-335 }
+projects:            { lines: 339-354 }
+tests-page:          { lines: 358-394 }
+recorder:            { lines: 397-415 }
+runs:                { lines: 418-441 }
+ai-fix:              { lines: 444-467 }
+test-code-editing:   { lines: 470-499 }
+automation:          { lines: 502-526 }
+visual-testing:      { lines: 529-546 }
+dashboard:           { lines: 549-566 }
+ai-chat:             { lines: 569-599 }
+settings:            { lines: 602-620 }
+account-gdpr:        { lines: 623-633 }
+email-verification:  { lines: 636-644 }
+recycle-bin:         { lines: 647-657 }
+audit-log:           { lines: 660-669 }
+notifications:       { lines: 672-703 }
+security:            { lines: 706-733 }
+reports-pdf:         { lines: 737-753 }
+system-diagnostics:  { lines: 756-766 }
+new-project:         { lines: 769-781 }
+runs-list:           { lines: 784-795 }
+project-detail:      { lines: 798-810 }
+bulk-actions:        { lines: 813-841 }
+modals:              { lines: 844-863 }
+api-test-imports:    { lines: 866-882 }
+onboarding:          { lines: 885-895 }
+demo-mode:           { lines: 898-910 }
+settings-data-tab:   { lines: 913-928 }
+workspace-switcher:  { lines: 931-940 }
+
+# Meta sections
+golden-happy-path:       { lines: 180-279 }
+canonical-ui-test-shape: { lines: 34-48 }
+permissions-matrix:      { lines: 91-139 }
+setup:                   { lines: 143-177 }
+cross-cutting-checks:    { lines: 943-970 }
+known-issues:            { lines: 973-985 }
+bug-template:            { lines: 988-1021 }
+coverage-checklist:      { lines: 1025-1069 }
+```
+
+> **Read-only boundary:** line ranges are approximate and can drift ±5 lines after edits — always stop at the next `### ` heading. Don't read beyond the listed range for a given section.
 
 > ⚠️ **Agents generating Playwright tests for Sentri: read this.**
 > Sentri's primary output is **UI / browser tests** that drive a real browser via `await page.goto(...)`, role-based selectors (`getByRole` / `getByLabel` / `getByText`), `safeClick` / `safeFill`, and `expect(page....)` assertions on rendered DOM.

--- a/QA.md
+++ b/QA.md
@@ -24,6 +24,12 @@ This file is ~1000 lines. **Do not read it top-to-bottom.** Jump to the section 
 | Per-feature checks | jump to `### <feature>` (Authentication, Workspaces, Projects, Tests Page, Recorder, Runs, AI Fix, Test Code Editing, Automation, Visual Testing, Dashboard, AI Chat, Settings, Account / GDPR, Email Verification, Recycle Bin, Audit Log, Notifications, Security, Reports, System Diagnostics, New Project, Runs List, Project Detail, Bulk Actions, Modals, Imports, Onboarding, Demo Mode, Workspace Switcher) |
 | Bug template | [Bug Reporting Template](#-bug-reporting-template) |
 | What's in / out of scope | [Coverage Checklist](#-coverage-checklist) and `backend/src/middleware/permissions.json#outOfScope` |
+| Generating tests for the deployed app | [Tests Page → UI / browser test generation](#-tests-page) — **UI tests are the default output**; API tests are additional |
+
+> ⚠️ **Agents generating Playwright tests for Sentri: read this.**
+> Sentri's primary output is **UI / browser tests** that drive a real browser via `await page.goto(...)`, role-based selectors (`getByRole` / `getByLabel` / `getByText`), `safeClick` / `safeFill`, and `expect(page....)` assertions on rendered DOM.
+> API tests using `request.fetch` / `request.get` / `request.post` are an **additional, secondary** output — only valid when same-origin fetch/XHR was captured during a crawl, or the user explicitly asked for an API test (OpenAPI / HAR / `METHOD /path`).
+> **If you emit only `request.*` tests when asked for "Playwright tests for Sentri", you have misread this guide.** Default to UI tests unless the user explicitly says "API test".
 
 **When adding a new user-facing flow** (per [REVIEW.md](./REVIEW.md)):
 1. Add a section here under "Functional Test Areas".

--- a/QA.md
+++ b/QA.md
@@ -31,6 +31,22 @@ This file is ~1000 lines. **Do not read it top-to-bottom.** Jump to the section 
 > API tests using `request.fetch` / `request.get` / `request.post` are an **additional, secondary** output — only valid when same-origin fetch/XHR was captured during a crawl, or the user explicitly asked for an API test (OpenAPI / HAR / `METHOD /path`).
 > **If you emit only `request.*` tests when asked for "Playwright tests for Sentri", you have misread this guide.** Default to UI tests unless the user explicitly says "API test".
 
+**Canonical UI test shape — emit this by default:**
+
+```js
+test('user can log in', async ({ page }) => {
+  await page.goto('https://rameshbabuprudhvi.github.io/sentri/login');
+  await safeFill(page.getByLabel('Email'), 'user@example.test');
+  await safeFill(page.getByLabel('Password'), 'pw');
+  await safeClick(page.getByRole('button', { name: 'Sign in' }));
+  await expect(page).toHaveURL(/dashboard/);
+  await expect(page.getByRole('heading', { name: /workspace/i })).toBeVisible();
+  await expect(page.getByRole('navigation')).toBeVisible();
+});
+```
+
+No `import` lines. No `request.fetch` / `request.get` / `request.post`. Role-based selectors. ≥ 3 `expect(page....)` assertions on visible UI state.
+
 **When adding a new user-facing flow** (per [REVIEW.md](./REVIEW.md)):
 1. Add a section here under "Functional Test Areas".
 2. Add a step (or sub-section) in the Golden E2E Happy Path if it belongs in the must-pass journey.
@@ -347,7 +363,7 @@ Each area uses this format:
 1. Crawl URL — verify **both crawl modes** (`README.md`):
    - **Link Crawl** — follows `<a>` tags, maps pages.
    - **State Exploration** — clicks/fills/submits to discover multi-step flows (auth, checkout).
-   Each mode completes, discovered pages listed, progress visible. Same-origin fetch/XHR captured (powers API test generation).
+   Each mode completes, discovered pages listed, progress visible. **Primary output: UI / browser tests** (see §3 below). Same-origin fetch/XHR is also captured and powers API test generation as a secondary output (see §4).
 2. Generate tests — verify the **8-stage AI pipeline** runs (`README.md`): discover → filter → classify → plan → generate → deduplicate → enhance → validate. Tests appear in **Draft** queue (`README.md`: "Nothing executes until a human approves it").
 3. **UI / browser test generation (default output)** — three paths, all produce tests that drive a real browser:
    - During **Link Crawl**: discovered pages → Playwright tests with `page.goto(...)` + `getByRole` / `getByLabel` / `getByText` + ≥ 3 `expect(...)` assertions on visible UI state.
@@ -833,8 +849,8 @@ For each modal: open → fill → submit → close behavior.
 
 | Modal | Trigger | Verify |
 |---|---|---|
-| **CrawlProjectModal** | "Crawl" quick action | Default project pre-selected; mode picker (Link Crawl / State Exploration); Test Dials presets; submit kicks off crawl + closes modal |
-| **GenerateTestModal** | "Generate Test" | Plain-English input, OpenAPI upload, HAR upload, paste `METHOD /path` patterns; submit creates Draft tests |
+| **CrawlProjectModal** | "Crawl" quick action | Default project pre-selected; mode picker (Link Crawl / State Exploration); Test Dials presets; submit kicks off crawl + closes modal. **Output: UI / browser tests** (Draft) — `page.goto` + role selectors + `safeClick` / `safeFill`; same-origin fetch/XHR additionally yields API tests |
+| **GenerateTestModal** | "Generate Test" | **Default output: UI / browser tests** from the crawl context. API-shaped inputs (plain-English endpoint, OpenAPI upload, HAR upload, `METHOD /path` paste) produce API tests only when explicitly used; submit creates Draft tests |
 | **RunRegressionModal** | "Run Regression" | Project picker, browser selector (Chromium/Firefox/WebKit), device dropdown, parallelism 1–10; submit opens RunDetail |
 | **ReviewModal** | "Review" / opening a Draft | Step-by-step approval queue; Approve/Reject/Skip; advances to next test |
 | **RecorderModal** | "Record a test" | Live CDP screencast; record/stop controls; on stop saves Draft |
@@ -847,7 +863,9 @@ For each modal: open → fill → submit → close behavior.
 
 ---
 
-### 📤 Imports (OpenAPI, HAR, plain-English API)
+### 📤 API Test Imports (OpenAPI, HAR, plain-English API)
+
+> Scope: this section covers **API test** generation paths only. UI / browser tests are generated from crawls and the Recorder — see [Tests Page §3](#-tests-page) and [Recorder](#-recorder).
 
 **Preconditions:** GenerateTestModal open.
 
@@ -1016,7 +1034,8 @@ Mark status per browser: ✅ pass · ❌ fail · ⚠️ partial · ⬜ not teste
 | Workspaces | ⬜ | ⬜ | ⬜ | ⬜ | |
 | Projects | ⬜ | ⬜ | ⬜ | ⬜ | |
 | Tests (crawl modes, generate, search, exports) | ⬜ | ⬜ | ⬜ | ⬜ | |
-| API Test Generation | ⬜ | ⬜ | ⬜ | ⬜ | |
+| **UI / Browser Test Generation (default output)** | ⬜ | ⬜ | ⬜ | ⬜ | |
+| API Test Generation (additional output) | ⬜ | ⬜ | ⬜ | ⬜ | |
 | Recorder | ⬜ | ⬜ | ⬜ | ⬜ | |
 | Runs (cross-browser, mobile, parallel, abort, self-heal) | ⬜ | ⬜ | ⬜ | ⬜ | |
 | **AI Fix (manual + auto feedback loop)** | ⬜ | ⬜ | ⬜ | ⬜ | |

--- a/QA.md
+++ b/QA.md
@@ -23,65 +23,65 @@ If the user asks for… read only this section:
 
 | User intent | Section (anchor) | Lines |
 |---|---|---|
-| "Run / write all happy paths" | [Golden E2E Happy Path](#-golden-e2e-happy-path-must-pass-before-release) | 180–279 |
-| "Write Playwright tests for the deployed app" | [Canonical UI test shape](#canonical-ui-test-shape--emit-this-by-default) + [Tests Page §3](#-tests-page) | 34–48, 358–394 |
-| "Write an API test" | [Tests Page §4](#-tests-page) + [API Test Imports](#-api-test-imports-openapi-har-plain-english-api) | 358–394, 866–882 |
-| "Fix a failing test" | [AI Fix](#-ai-fix-failed-test-recovery) | 444–467 |
-| "Record a test" | [Recorder](#-recorder) | 397–415 |
-| "Run tests / regression" | [Runs](#%EF%B8%8F-runs) | 418–441 |
-| "Edit test code / steps" | [Test Code Editing](#%EF%B8%8F-test-code-editing-steps--source) | 470–499 |
-| "Schedule / trigger from CI" | [Automation](#-automation-cicd--scheduled-runs) | 502–526 |
-| "Visual / screenshot testing" | [Visual Testing](#%EF%B8%8F-visual-testing) | 529–546 |
+| "Run / write all happy paths" | [Golden E2E Happy Path](#-golden-e2e-happy-path-must-pass-before-release) | 240–339 |
+| "Write Playwright tests for the deployed app" | [Canonical UI test shape](#canonical-ui-test-shape--emit-this-by-default) + [Tests Page §3](#-tests-page) | 94–108, 418–453 |
+| "Write an API test" | [Tests Page §4](#-tests-page) + [API Test Imports](#-api-test-imports-openapi-har-plain-english-api) | 418–453, 926–941 |
+| "Fix a failing test" | [AI Fix](#-ai-fix-failed-test-recovery) | 504–527 |
+| "Record a test" | [Recorder](#-recorder) | 457–475 |
+| "Run tests / regression" | [Runs](#%EF%B8%8F-runs) | 478–501 |
+| "Edit test code / steps" | [Test Code Editing](#%EF%B8%8F-test-code-editing-steps--source) | 530–559 |
+| "Schedule / trigger from CI" | [Automation](#-automation-cicd--scheduled-runs) | 562–586 |
+| "Visual / screenshot testing" | [Visual Testing](#%EF%B8%8F-visual-testing) | 589–606 |
 | "Verify permissions" | [`permissions.json`](./backend/src/middleware/permissions.json) **(canonical, read this, not prose)** | — |
-| "Verify security / authorization" | [Security](#-security) | 706–733 |
-| "Bulk actions / keyboard shortcuts" | [Bulk Actions](#%EF%B8%8F-bulk-actions--keyboard-shortcuts) | 813–841 |
-| "Report a bug" | [Bug Reporting Template](#-bug-reporting-template) | 988–1021 |
+| "Verify security / authorization" | [Security](#-security) | 766–794 |
+| "Bulk actions / keyboard shortcuts" | [Bulk Actions](#%EF%B8%8F-bulk-actions--keyboard-shortcuts) | 873–900 |
+| "Report a bug" | [Bug Reporting Template](#-bug-reporting-template) | 1048–1080 |
 
 ### Section index (line ranges, for `sed -n 'A,Bp'` / partial reads)
 
 ```yaml
 # Feature sections
-authentication:      { lines: 293-316 }
-workspaces:          { lines: 319-335 }
-projects:            { lines: 339-354 }
-tests-page:          { lines: 358-394 }
-recorder:            { lines: 397-415 }
-runs:                { lines: 418-441 }
-ai-fix:              { lines: 444-467 }
-test-code-editing:   { lines: 470-499 }
-automation:          { lines: 502-526 }
-visual-testing:      { lines: 529-546 }
-dashboard:           { lines: 549-566 }
-ai-chat:             { lines: 569-599 }
-settings:            { lines: 602-620 }
-account-gdpr:        { lines: 623-633 }
-email-verification:  { lines: 636-644 }
-recycle-bin:         { lines: 647-657 }
-audit-log:           { lines: 660-669 }
-notifications:       { lines: 672-703 }
-security:            { lines: 706-733 }
-reports-pdf:         { lines: 737-753 }
-system-diagnostics:  { lines: 756-766 }
-new-project:         { lines: 769-781 }
-runs-list:           { lines: 784-795 }
-project-detail:      { lines: 798-810 }
-bulk-actions:        { lines: 813-841 }
-modals:              { lines: 844-863 }
-api-test-imports:    { lines: 866-882 }
-onboarding:          { lines: 885-895 }
-demo-mode:           { lines: 898-910 }
-settings-data-tab:   { lines: 913-928 }
-workspace-switcher:  { lines: 931-940 }
+authentication:      { lines: 353-376 }
+workspaces:          { lines: 379-395 }
+projects:            { lines: 399-414 }
+tests-page:          { lines: 418-453 }
+recorder:            { lines: 457-475 }
+runs:                { lines: 478-501 }
+ai-fix:              { lines: 504-527 }
+test-code-editing:   { lines: 530-559 }
+automation:          { lines: 562-586 }
+visual-testing:      { lines: 589-606 }
+dashboard:           { lines: 609-625 }
+ai-chat:             { lines: 629-658 }
+settings:            { lines: 662-679 }
+account-gdpr:        { lines: 683-692 }
+email-verification:  { lines: 696-703 }
+recycle-bin:         { lines: 707-716 }
+audit-log:           { lines: 720-728 }
+notifications:       { lines: 732-762 }
+security:            { lines: 766-794 }
+reports-pdf:         { lines: 797-812 }
+system-diagnostics:  { lines: 816-825 }
+new-project:         { lines: 829-840 }
+runs-list:           { lines: 844-854 }
+project-detail:      { lines: 858-869 }
+bulk-actions:        { lines: 873-900 }
+modals:              { lines: 904-922 }
+api-test-imports:    { lines: 926-941 }
+onboarding:          { lines: 945-954 }
+demo-mode:           { lines: 958-969 }
+settings-data-tab:   { lines: 973-987 }
+workspace-switcher:  { lines: 991-999 }
 
 # Meta sections
-golden-happy-path:       { lines: 180-279 }
-canonical-ui-test-shape: { lines: 34-48 }
-permissions-matrix:      { lines: 91-139 }
-setup:                   { lines: 143-177 }
-cross-cutting-checks:    { lines: 943-970 }
-known-issues:            { lines: 973-985 }
-bug-template:            { lines: 988-1021 }
-coverage-checklist:      { lines: 1025-1069 }
+golden-happy-path:       { lines: 240-339 }
+canonical-ui-test-shape: { lines: 94-108 }
+permissions-matrix:      { lines: 151-199 }
+setup:                   { lines: 203-237 }
+cross-cutting-checks:    { lines: 1003-1029 }
+known-issues:            { lines: 1033-1044 }
+bug-template:            { lines: 1048-1081 }
+coverage-checklist:      { lines: 1085-1129 }
 ```
 
 > **Read-only boundary:** line ranges are approximate and can drift ±5 lines after edits — always stop at the next `### ` heading. Don't read beyond the listed range for a given section.

--- a/QA.md
+++ b/QA.md
@@ -35,7 +35,7 @@ If the user asks for… read only this section:
 | "Verify permissions" | [`permissions.json`](./backend/src/middleware/permissions.json) **(canonical, read this, not prose)** | — |
 | "Verify security / authorization" | [Security](#-security) | 766–794 |
 | "Bulk actions / keyboard shortcuts" | [Bulk Actions](#%EF%B8%8F-bulk-actions--keyboard-shortcuts) | 873–900 |
-| "Report a bug" | [Bug Reporting Template](#-bug-reporting-template) | 1048–1080 |
+| "Report a bug" | [Bug Reporting Template](#-bug-reporting-template) | 1048–1081 |
 
 ### Section index (line ranges, for `sed -n 'A,Bp'` / partial reads)
 
@@ -91,7 +91,7 @@ coverage-checklist:      { lines: 1085-1129 }
 > API tests using `request.fetch` / `request.get` / `request.post` are an **additional, secondary** output — only valid when same-origin fetch/XHR was captured during a crawl, or the user explicitly asked for an API test (OpenAPI / HAR / `METHOD /path`).
 > **If you emit only `request.*` tests when asked for "Playwright tests for Sentri", you have misread this guide.** Default to UI tests unless the user explicitly says "API test".
 
-**Canonical UI test shape — emit this by default:**
+#### Canonical UI test shape — emit this by default
 
 ```js
 test('user can log in', async ({ page }) => {

--- a/QA.md
+++ b/QA.md
@@ -175,10 +175,13 @@ Run this single end-to-end journey **as User A (admin)** in a fresh browser. Eve
 ### 4. Discover — crawl the app
 6. Trigger **Link Crawl** → progress visible; pages discovered; same-origin fetch/XHR captured.
 7. Trigger **State Exploration** crawl on the same project → multi-step flows discovered (forms submitted, auth flows entered).
-
 ### 5. Generate — AI tests
 8. Click **Generate** → 8-stage pipeline runs (discover → filter → classify → plan → generate → deduplicate → enhance → validate). New tests land in **Draft** queue, not auto-approved.
-9. Verify at least one **API test** was generated from captured fetch/XHR (Playwright `request` test asserting status + JSON shape).
+9. Verify **both test types** were produced — Sentri generates **UI / browser tests by default**; API tests are an additional output:
+   - **UI / browser test (primary)** — uses `await page.goto(...)`, role-based selectors (`getByRole` / `getByLabel` / `getByText`), `safeClick` / `safeFill`, and ≥ 3 `expect(...)` assertions on visible UI state. Drives a real browser. **No `request.` / `request.fetch` / `request.get` calls.**
+   - **API test (only if same-origin fetch/XHR was captured)** — Playwright `request` test asserting status + JSON shape.
+   If only API tests appear, the crawl did not discover UI flows — re-run **State Exploration** and regenerate.
+
 
 ### 6. Record — manual recorder
 10. Click **Record a test** → Playwright browser opens via CDP screencast.
@@ -340,16 +343,21 @@ Each area uses this format:
    - **State Exploration** — clicks/fills/submits to discover multi-step flows (auth, checkout).
    Each mode completes, discovered pages listed, progress visible. Same-origin fetch/XHR captured (powers API test generation).
 2. Generate tests — verify the **8-stage AI pipeline** runs (`README.md`): discover → filter → classify → plan → generate → deduplicate → enhance → validate. Tests appear in **Draft** queue (`README.md`: "Nothing executes until a human approves it").
-3. **API test generation** (`README.md`) — three paths:
+3. **UI / browser test generation (default output)** — three paths, all produce tests that drive a real browser:
+   - During **Link Crawl**: discovered pages → Playwright tests with `page.goto(...)` + `getByRole` / `getByLabel` / `getByText` + ≥ 3 `expect(...)` assertions on visible UI state.
+   - During **State Exploration** crawl: multi-step flows (login, form submit, checkout) → tests using `safeClick` / `safeFill` so self-healing engages at run time.
+   - **Recorder**: user-driven click/fill/press/select/navigate (see Recorder section).
+   Each path produces a Playwright test that opens a browser, navigates pages, and asserts on rendered DOM. **No `request.fetch` / `request.get` / `request.post` calls.**
+4. **API test generation (additional output)** — three paths, all produce Playwright `request` tests (no browser):
    - During crawl: same-origin fetch/XHR auto-generated as Playwright `request` tests.
    - "Generate Test" modal: plain-English endpoint description.
    - Paste `METHOD /path` patterns or attach an OpenAPI spec.
    Each path produces tests that verify status codes, JSON shape, error payloads.
-4. Approve test → moves to active suite; appears in run targets.
-5. Reject test → removed/archived; excluded from regression.
-6. Edit test steps (add/remove/reorder) → saved; preview reflects changes.
-7. **Search** tests via `?search=` (`/api/v1/projects/:id/tests?search=`) → filters list correctly; empty results show empty state.
-8. **Exports** (`backend/src/routes/tests.js`):
+5. Approve test → moves to active suite; appears in run targets.
+6. Reject test → removed/archived; excluded from regression.
+7. Edit test steps (add/remove/reorder) → saved; preview reflects changes.
+8. **Search** tests via `?search=` (`/api/v1/projects/:id/tests?search=`) → filters list correctly; empty results show empty state.
+9. **Exports** (`backend/src/routes/tests.js`):
    - `GET /api/v1/projects/:id/tests/export/zephyr` — Zephyr Scale CSV.
    - `GET /api/v1/projects/:id/tests/export/testrail` — TestRail CSV.
    - `GET /api/v1/projects/:id/tests/traceability` — traceability matrix.

--- a/qa-run-issues.md
+++ b/qa-run-issues.md
@@ -1,0 +1,62 @@
+# QA Live-Run Issues
+
+> Template for tracking issues found during a live browser QA run against the
+> deployed Sentri (`https://rameshbabuprudhvi.github.io/sentri`) driven from
+> `QA.md`. One row per issue. Keep the summary table in sync with the detailed
+> entries below.
+>
+> **Workflow:** during a run, append a detailed entry first, then add a one-line
+> row to the summary table. At the end of the run, sort the summary by severity
+> (blocker → major → minor).
+
+## Run metadata
+
+- **Run date:** `YYYY-MM-DD`
+- **Runner:** `<agent or human>`
+- **Branch:** `qa/live-browser-run-YYYY-MM-DD`
+- **Target URL:** `https://rameshbabuprudhvi.github.io/sentri`
+- **QA.md commit:** `<sha>`
+- **Playwright version:** `<x.y.z>`
+
+## Summary
+
+| # | Severity | Flow | QA.md § (lines) | One-line observation | Owner |
+|---|---|---|---|---|---|
+| 1 | blocker / major / minor | Authentication | `authentication` (353–376) | e.g. "Sign-in button has no accessible name" | frontend |
+
+## Flow status
+
+| Flow | QA.md lines | Status | Notes |
+|---|---|---|---|
+| Authentication | 353–376 | ⬜ pending / 🟡 in progress / ✅ pass / ❌ issues | |
+| Workspaces | 379–395 | ⬜ | |
+| Projects | 399–414 | ⬜ | |
+| Tests Page (UI generation §3) | 418–453 | ⬜ | |
+| Recorder | 457–475 | ⬜ | |
+| Runs | 478–501 | ⬜ | |
+| AI Fix | 504–527 | ⬜ | |
+| Golden E2E Happy Path | 240–339 | ⬜ | |
+
+## Issues (detailed)
+
+### Issue 1 — `<short title>`
+
+- **Severity:** blocker / major / minor
+- **Flow:** `<flow name>`
+- **QA.md section:** `<anchor>` (lines `A–B`)
+- **Observed:** what actually happened
+- **Expected:** what `QA.md` says should happen
+- **Repro steps:**
+  1. `await page.goto('https://rameshbabuprudhvi.github.io/sentri/...')`
+  2. `<selector / action>`
+  3. `<assertion that failed>`
+- **Console / network excerpt:**
+  ```
+  <paste relevant log lines, redact tokens>
+  ```
+- **Screenshot:** `artifacts/run-YYYY-MM-DD/issue-1.png`
+- **Proposed fix owner:** frontend / backend / docs
+- **Proposed fix sketch:** one or two lines, no code change required here
+- **Status:** open / fixed-in-this-pr / deferred-to-followup
+
+<!-- Duplicate the block above for each subsequent issue. -->


### PR DESCRIPTION

## What does this PR do?

## Problem
Users feeding `QA.md` to Claude and Codex to generate live browser
tests for the deployed Sentri (https://rameshbabuprudhvi.github.io/sentri)
get back **Playwright `request.*` API tests** instead of the intended
**`page.*` browser tests**.
## Root cause
`QA.md` (added in #112) over-indexes on API test generation:
- Golden step 9 names "API test" with a concrete code shape:
  *"Playwright `request` test asserting status + JSON shape"*.
- Tests Page section 3 has a dedicated **"API test generation"**
  subsection with three paths.
- Imports section leads with OpenAPI / HAR / plain-English API.
- The crawl description repeatedly emphasizes captured fetch/XHR.
UI test generation has **no equivalent named subsection or code-shape
contract**. The only place UI code shape appears is buried in step 16
(about *editing*, not generating). LLMs latch onto the explicit,
shape-described instruction → emit `request.*` tests.

## Fix
Three docs-only edits to `QA.md`:
1. **Golden step 9** — require both UI and API tests, with UI named
   first and given a concrete code shape.
2. **Tests Page section 3** — split into "UI test generation
   (default)" and "API test generation (additional)", each with the
   same three-paths treatment.
3. **For-agents block** — add a lookup row and a bold callout
   explicitly warning agents that emitting only `request.fetch` tests
   means they misread the guide.
## Verification
After this PR, paste `QA.md` into Claude / Codex and ask:
*"Write 3 Playwright tests for the login flow on the deployed Sentri."*
Expected: tests using `page.goto`, `getByRole`, `safeClick`, `expect(page.*)`.
Before this PR: tests using `request.post('/api/auth/login')`.
## Out of scope
- No code changes.
- Does not change the actual generation pipeline (which already
  prefers UI tests — this is purely a docs-readability fix for agents).
- Does not address the broader "dogfood Sentri on Sentri" / Render
  seed work the user mentioned — that needs a separate PR.

## Linked issue

Closes #<!-- issue number — PRs without a linked issue for non-trivial changes are closed -->

## Type of change

- [ ] Bug fix
- [ ] New feature (exists in ROADMAP.md)
- [ ] Refactor / performance improvement
- [x ] Documentation / tests only

## Checklist

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `perf:`, `docs:`, etc.)
- [ ] Branch is off `develop`, not `main`
- [ ] `cd backend && npm test` passes locally
- [ ] `cd frontend && npm run build && npm test` passes locally
- [ ] New/modified backend logic has tests registered in `backend/tests/run-tests.js`
- [ ] `docs/changelog.md` updated under `## [Unreleased]` (user-visible changes only)
- [ ] `QA.md` walked for affected flows; Golden E2E re-run if core flow was touched
- [ ] `permissions.json` updated if a `requireRole()` gate was added/changed
- [ ] ROADMAP.md + NEXT.md updated if this closes a roadmap item (see REVIEW.md)
- [ ] No secrets, API keys, or credentials in the diff

## How to test

<!-- Step-by-step instructions a reviewer can follow to verify this works. -->

1. 
2. 
3. 

## Screenshots (if UI changed)

<!-- Delete this section if not applicable -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rameshbabuprudhvi/sentri/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
