### PR TITLE
feat: persist Web Vitals metric samples for trend charts

### DIFF
--- a/backend/src/testRunner.js
+++ b/backend/src/testRunner.js
@@ -43,6 +43,7 @@ import * as runRepo from "./database/repositories/runRepo.js";
 import { signRunArtifacts, signArtifactUrl } from "./middleware/appSetup.js";
 import { writeArtifactBuffer } from "./utils/objectStorage.js";
 import fs from "fs";
+import { recordMetric } from "./utils/recordMetric.js";
 
 
 function evaluateQualityGates(gates, run) {
@@ -391,6 +392,27 @@ export async function runTests(project, tests, run, { parallelWorkers, browser: 
 
   run.gateResult = evaluateQualityGates(project.qualityGates, run);
   run.webVitalsResult = evaluateWebVitalsBudgets(project.webVitalsBudgets, run);
+
+  // AUTO-017.3: persist per-run Web Vitals samples for MET-001 trend charts.
+  // Best-effort only — telemetry failures must never fail the run.
+  try {
+    const rows = Array.isArray(run.results) ? run.results : [];
+    const keys = ["lcp", "cls", "inp", "ttfb"];
+    for (const key of keys) {
+      const values = rows
+        .map((r) => Number(r?.webVitals?.[key]))
+        .filter((v) => Number.isFinite(v));
+      if (values.length === 0) continue;
+      const avg = values.reduce((sum, v) => sum + v, 0) / values.length;
+      const threshold = Number(project?.webVitalsBudgets?.[key]);
+      recordMetric(project.id, `webVitals.${key}`, avg, { runId, source: "run", metric: key }, runStart);
+      if (Number.isFinite(threshold)) {
+        recordMetric(project.id, `webVitals.${key}.budget`, threshold, { runId, source: "budget", metric: key }, runStart);
+      }
+    }
+  } catch (metricErr) {
+    logWarn(run, `Web Vitals trend metric write failed: ${metricErr.message}`);
+  }
 
   // NOTE: We intentionally keep run.status === "running" here so that:
   //   1. The abort endpoint (POST /api/runs/:id/abort) still works during the

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -75,6 +75,7 @@ const files = [
   "tests/run-compare.test.js",
   "tests/metric-samples.test.js",
   "tests/healing-summary.test.js",
+  "tests/web-vitals-trend.test.js",
 ];
 
 let passed = 0;

--- a/backend/tests/web-vitals-trend.test.js
+++ b/backend/tests/web-vitals-trend.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getDatabase } from "../src/database/sqlite.js";
+import { runTests } from "../src/testRunner.js";
+import * as metricSamplesRepo from "../src/database/repositories/metricSamplesRepo.js";
+
+const db = getDatabase();
+
+test("runTests records Web Vitals metric samples for trend charts", async () => {
+  const projectId = `PRJ-WVT-${Date.now()}`;
+  db.prepare(`INSERT INTO projects (id, name, url, createdAt) VALUES (?, ?, ?, ?)`)
+    .run(projectId, "Vitals Project", "https://example.com", new Date().toISOString());
+
+  const project = {
+    id: projectId,
+    name: "Vitals Project",
+    url: "https://example.com",
+    webVitalsBudgets: { lcp: 2500, cls: 0.1, inp: 200, ttfb: 800 },
+  };
+
+  const run = {
+    id: `RUN-WVT-${Date.now()}`,
+    status: "running",
+    passed: 0,
+    failed: 0,
+    total: 0,
+    results: [
+      { testId: "T1", testName: "a", webVitals: { lcp: 2300, cls: 0.08, inp: 140, ttfb: 420 } },
+      { testId: "T2", testName: "b", webVitals: { lcp: 2700, cls: 0.12, inp: 180, ttfb: 500 } },
+    ],
+  };
+
+  await runTests(project, [], run, {});
+
+  const lcpSeries = metricSamplesRepo.getSeries(projectId, "webVitals.lcp", { limit: 5 });
+  const clsSeries = metricSamplesRepo.getSeries(projectId, "webVitals.cls", { limit: 5 });
+  const budgetSeries = metricSamplesRepo.getSeries(projectId, "webVitals.lcp.budget", { limit: 5 });
+
+  assert.ok(lcpSeries.length >= 1);
+  assert.ok(clsSeries.length >= 1);
+  assert.ok(budgetSeries.length >= 1);
+
+  const lastLcp = lcpSeries.at(-1);
+  assert.equal(lastLcp.value, 2500);
+});


### PR DESCRIPTION
### Motivation
- Enable MET-001-backed trend visuals by persisting per-run Web Vitals samples (LCP/CLS/INP/TTFB) so frontend `<TrendChart>` consumers can plot historical metrics with contextual budget lines.

### Description
- After `evaluateWebVitalsBudgets()` in `backend/src/testRunner.js`, compute per-run averages for `lcp`, `cls`, `inp`, and `ttfb` and record them via `recordMetric(project.id, "webVitals.<metric>", ...)` in a best-effort `try/catch` block so telemetry failures do not fail the run. 
- When a project budget exists, also record companion budget samples as `webVitals.<metric>.budget` (tagged with run metadata) so charts can show threshold lines. 
- Added `backend/tests/web-vitals-trend.test.js` to validate ingestion of metric samples and budget samples, and registered the new test in `backend/tests/run-tests.js`.

### Testing
- Attempted to run the new backend test with `cd backend && node tests/web-vitals-trend.test.js`, but the run failed due to a missing native dependency (`better-sqlite3`), producing `ERR_MODULE_NOT_FOUND`; no other automated tests were executed in this environment. 
- The new test file is included in the unified backend test runner (`backend/tests/run-tests.js`) so CI with dependencies available should execute it as part of the backend test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa3fe6da1083269f62c33f4cd12b79)