### PR TITLE
feat(auto-003): add confidence-based auto-approval persistence and schema support

### DIFF
--- a/backend/src/database/migrations/017_auto_approval.sql
+++ b/backend/src/database/migrations/017_auto_approval.sql
@@ -1,0 +1,9 @@
+-- Migration 017: confidence scoring + auto-approval thresholds/provenance
+
+ALTER TABLE tests ADD COLUMN confidenceScore REAL;
+ALTER TABLE tests ADD COLUMN approvalSource TEXT;
+ALTER TABLE tests ADD COLUMN approvalThreshold REAL;
+ALTER TABLE tests ADD COLUMN approvedAt TEXT;
+ALTER TABLE tests ADD COLUMN approvedBy TEXT;
+
+ALTER TABLE projects ADD COLUMN autoApproveThreshold REAL;

--- a/backend/src/database/repositories/projectRepo.js
+++ b/backend/src/database/repositories/projectRepo.js
@@ -21,6 +21,7 @@ function rowToProject(row) {
     credentials: row.credentials ? JSON.parse(row.credentials) : null,
     qualityGates: row.qualityGates ? JSON.parse(row.qualityGates) : null,
     webVitalsBudgets: row.webVitalsBudgets ? JSON.parse(row.webVitalsBudgets) : null,
+    autoApproveThreshold: row.autoApproveThreshold,
   };
 }
 
@@ -34,6 +35,7 @@ function projectToRow(p) {
     qualityGates: p.qualityGates ? JSON.stringify(p.qualityGates) : null,
     webVitalsBudgets: p.webVitalsBudgets ? JSON.stringify(p.webVitalsBudgets) : null,
     createdAt: p.createdAt,
+    autoApproveThreshold: p.autoApproveThreshold ?? null,
   };
 }
 
@@ -95,8 +97,8 @@ export function create(project) {
   const row = projectToRow(project);
   row.workspaceId = project.workspaceId || null;
   db.prepare(`
-    INSERT INTO projects (id, name, url, credentials, status, qualityGates, webVitalsBudgets, createdAt, workspaceId)
-    VALUES (@id, @name, @url, @credentials, @status, @qualityGates, @webVitalsBudgets, @createdAt, @workspaceId)
+    INSERT INTO projects (id, name, url, credentials, status, qualityGates, webVitalsBudgets, createdAt, workspaceId, autoApproveThreshold)
+    VALUES (@id, @name, @url, @credentials, @status, @qualityGates, @webVitalsBudgets, @createdAt, @workspaceId, @autoApproveThreshold)
   `).run(row);
 }
 
@@ -107,7 +109,7 @@ export function create(project) {
  */
 export function update(id, fields) {
   const db = getDatabase();
-  const allowed = ["name", "url", "credentials", "status", "qualityGates", "webVitalsBudgets"];
+  const allowed = ["name", "url", "credentials", "status", "qualityGates", "webVitalsBudgets", "autoApproveThreshold"];
   const sets = [];
   const params = { id };
   for (const key of allowed) {

--- a/backend/src/database/repositories/testRepo.js
+++ b/backend/src/database/repositories/testRepo.js
@@ -59,6 +59,7 @@ const INSERT_COLS = [
   "reviewedAt", "promptVersion", "modelUsed", "linkedIssueKey", "tags",
   "generatedFrom", "isApiTest", "scenario", "codeRegeneratedAt",
   "aiFixAppliedAt", "codeVersion", "workspaceId", "isStale", "flakyScore",
+  "confidenceScore", "approvalSource", "approvalThreshold", "approvedAt", "approvedBy",
 ];
 
 const INSERT_SQL = `INSERT INTO tests (${INSERT_COLS.join(", ")})

--- a/backend/src/pipeline/deduplicator.js
+++ b/backend/src/pipeline/deduplicator.js
@@ -323,7 +323,13 @@ export function deduplicateTests(tests) {
   for (const test of tests) {
     const hash = hashTest(test);
     const { score: quality, factors } = scoreTestWithFactors(test);
-    const testWithScore = { ...test, _hash: hash, _quality: quality, _qualityFactors: factors };
+    const testWithScore = {
+      ...test,
+      _hash: hash,
+      _quality: quality,
+      _qualityFactors: factors,
+      confidenceScore: quality,
+    };
 
     if (!hashMap.has(hash)) {
       hashMap.set(hash, testWithScore);

--- a/backend/src/pipeline/testPersistence.js
+++ b/backend/src/pipeline/testPersistence.js
@@ -13,6 +13,7 @@ import { generateTestId } from "../utils/idGenerator.js";
 import { getProviderName } from "../aiProvider.js";
 import { PROMPT_VERSION } from "./prompts/outputSchema.js";
 import * as testRepo from "../database/repositories/testRepo.js";
+import { logActivity } from "../utils/activityLogger.js";
 
 /**
  * Write validated test objects into SQLite and update the run record.
@@ -25,8 +26,12 @@ import * as testRepo from "../database/repositories/testRepo.js";
  */
 export function persistGeneratedTests(validatedTests, project, run, defaults = {}) {
   const createdTestIds = [];
+  const threshold = Number.isFinite(project?.autoApproveThreshold) ? project.autoApproveThreshold : null;
   for (const t of validatedTests) {
     const testId = generateTestId();
+    const confidenceScore = Number.isFinite(t?.confidenceScore) ? t.confidenceScore : (t._quality || 0);
+    const autoApproved = threshold !== null && confidenceScore >= threshold;
+    const approvedAt = autoApproved ? new Date().toISOString() : null;
     const test = {
       // Spread AI-generated fields first so our critical fields below always win.
       // This prevents the AI from accidentally overriding id, projectId, reviewStatus, etc.
@@ -41,6 +46,7 @@ export function persistGeneratedTests(validatedTests, project, run, defaults = {
       lastResult: null,
       lastRunAt: null,
       qualityScore: t._quality || 0,
+      confidenceScore,
       // Per-factor breakdown that produced `qualityScore` — surfaced as the
       // "why was this drafted?" explainer in the Review Queue. `_qualityFactors`
       // is set by `deduplicateTests`; we coerce missing data to `[]` so the
@@ -52,8 +58,12 @@ export function persistGeneratedTests(validatedTests, project, run, defaults = {
       journeyType: t.journeyType || null,
       assertionEnhanced: t._assertionEnhanced || false,
       // All generated tests start as draft — humans must approve before regression
-      reviewStatus: "draft",
-      reviewedAt: null,
+      reviewStatus: autoApproved ? "approved" : "draft",
+      reviewedAt: approvedAt,
+      approvalSource: autoApproved ? "auto" : null,
+      approvalThreshold: autoApproved ? threshold : null,
+      approvedAt,
+      approvedBy: autoApproved ? "auto-approver" : null,
       // Traceability — which prompt version and AI model produced this test
       promptVersion: PROMPT_VERSION,
       modelUsed: getProviderName(),
@@ -67,6 +77,18 @@ export function persistGeneratedTests(validatedTests, project, run, defaults = {
       workspaceId: project.workspaceId || null,
     };
     testRepo.create(test);
+    if (autoApproved) {
+      logActivity({
+        type: "test.auto_approved",
+        projectId: project.id,
+        projectName: project.name,
+        testId,
+        testName: test.name,
+        detail: `Auto-approved at confidence ${confidenceScore.toFixed(2)} (threshold ${threshold.toFixed(2)})`,
+        userName: "auto-approver",
+        workspaceId: project.workspaceId || null,
+      });
+    }
     run.tests.push(testId);
     createdTestIds.push(testId);
   }

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -146,6 +146,13 @@ router.patch("/:id", requireRole("qa_lead"), (req, res) => {
   const url  = req.body.url?.trim() || "";
 
   const fields = { name, url };
+  if (Object.hasOwn(req.body, "autoApproveThreshold")) {
+    const threshold = req.body.autoApproveThreshold;
+    if (threshold !== null && (!Number.isFinite(threshold) || threshold < 0 || threshold > 1)) {
+      return res.status(400).json({ error: "autoApproveThreshold must be null or a number between 0 and 1." });
+    }
+    fields.autoApproveThreshold = threshold;
+  }
 
   if (req.body.credentials === null) {
     fields.credentials = null;

--- a/backend/tests/auto-approval.test.js
+++ b/backend/tests/auto-approval.test.js
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { resetDb } from "./helpers/test-base.js";
+import * as testRepo from "../src/database/repositories/testRepo.js";
+import * as activityRepo from "../src/database/repositories/activityRepo.js";
+import { persistGeneratedTests } from "../src/pipeline/testPersistence.js";
+
+function makeRun() {
+  return { tests: [] };
+}
+
+function makeProject(overrides = {}) {
+  return {
+    id: "PRJ-1",
+    name: "Proj",
+    url: "https://example.com",
+    workspaceId: "ws-1",
+    ...overrides,
+  };
+}
+
+function makeTest(confidenceScore) {
+  return { name: "Generated", steps: ["step"], confidenceScore, _quality: confidenceScore };
+}
+
+async function main() {
+  resetDb();
+
+  {
+    const run = makeRun();
+    const ids = persistGeneratedTests([makeTest(0.95)], makeProject({ autoApproveThreshold: null }), run);
+    const saved = testRepo.getById(ids[0]);
+    assert.equal(saved.reviewStatus, "draft");
+    assert.equal(saved.approvalSource, null);
+  }
+
+  {
+    const run = makeRun();
+    const ids = persistGeneratedTests([makeTest(0.4)], makeProject({ autoApproveThreshold: 0.8 }), run);
+    const saved = testRepo.getById(ids[0]);
+    assert.equal(saved.reviewStatus, "draft");
+  }
+
+  {
+    const run = makeRun();
+    const ids = persistGeneratedTests([makeTest(0.9)], makeProject({ autoApproveThreshold: 0.8 }), run);
+    const saved = testRepo.getById(ids[0]);
+    assert.equal(saved.reviewStatus, "approved");
+    assert.equal(saved.approvalSource, "auto");
+    assert.equal(saved.approvalThreshold, 0.8);
+    assert.equal(saved.approvedBy, "auto-approver");
+    const activities = activityRepo.getFiltered({ type: "test.auto_approved", projectId: "PRJ-1" });
+    assert.ok(activities.some((a) => a.testId === ids[0] && a.userName === "auto-approver"));
+  }
+
+  console.log("✅ auto-approval passed");
+}
+
+main().catch((err) => {
+  console.error("❌ auto-approval failed:", err);
+  process.exit(1);
+});

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -76,6 +76,7 @@ const files = [
   "tests/metric-samples.test.js",
   "tests/healing-summary.test.js",
   "tests/web-vitals-trend.test.js",
+  "tests/auto-approval.test.js",
 ];
 
 let passed = 0;


### PR DESCRIPTION
### Motivation
- Enable AUTO-003 auto-approval: persist a numeric confidence score per generated test and allow per-project auto-approval thresholds so high-confidence tests can be auto-approved. 
- Provide audit/provenance for approvals so auto-approvals are attributable and reversible later (AUTO-003b groundwork). 
- Preserve default behavior for existing projects by making `autoApproveThreshold` nullable (disabled by default).

### Description
- Added migration `backend/src/database/migrations/017_auto_approval.sql` to add `tests.confidenceScore`, approval provenance columns (`approvalSource`, `approvalThreshold`, `approvedAt`, `approvedBy`) and `projects.autoApproveThreshold`.
- Emit `confidenceScore` out of the deduplicator by populating the dedupe output with `confidenceScore` (existing quality score propagated) in `backend/src/pipeline/deduplicator.js`.
- Implement auto-approval logic in `backend/src/pipeline/testPersistence.js` to: read `project.autoApproveThreshold`, auto-approve tests whose `confidenceScore >= threshold`, populate provenance fields, and write an activity log entry with `userName: "auto-approver"`.
- Extend DB repo mappings to include the new columns (`backend/src/database/repositories/testRepo.js` and `backend/src/database/repositories/projectRepo.js`) and allow creating/updating `autoApproveThreshold` (persisted as `null` or a number).
- Accept and validate `autoApproveThreshold` on project `PATCH /api/v1/projects/:id` in `backend/src/routes/projects.js` where the value must be `null` or a number in `[0,1]`.
- Added backend unit test `backend/tests/auto-approval.test.js` covering threshold-off, below-threshold, and above-threshold + activity-log cases and registered it in `backend/tests/run-tests.js`.

### Testing
- Ran the new unit test file `node backend/tests/auto-approval.test.js`; test execution failed in this environment due to a missing dependency (`dotenv`) imported by `backend/src/middleware/appSetup.js`, so the automated assertions could not be executed here (failure is environmental, not test logic).
- The new test file is included in the unified backend runner (`backend/tests/run-tests.js`).
- Database migration file and code changes were added and committed; full CI/test-suite should be run in the project environment (with dependencies installed) to validate migrations and the new auto-approval behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6e1198108326a138f574f428d2de)