### PR TITLE
feat(ai): add OpenAI-compatible provider slots (AI-001)

### DIFF
--- a/backend/src/aiProvider.js
+++ b/backend/src/aiProvider.js
@@ -31,6 +31,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import { throwIfAborted } from "./utils/abortHelper.js";
 import { formatLogLine } from "./utils/logFormatter.js";
 import * as apiKeyRepo from "./database/repositories/apiKeyRepo.js";
+import { validateUrl } from "./utils/ssrfGuard.js";
 
 // ── Runtime key store ────────────────────────────────────────────────────────
 // In-memory cache populated at startup from the DB (via loadKeysFromDatabase)
@@ -81,6 +82,7 @@ const CLOUD_KEY_MAP = {
   openai:     "OPENAI_API_KEY",
   google:     "GOOGLE_API_KEY",
   openrouter: "OPENROUTER_API_KEY",
+  openai_compatible: "OPENAI_COMPATIBLE_API_KEY",
 };
 
 // Default models per cloud provider — overridable via env vars
@@ -89,6 +91,7 @@ const CLOUD_DEFAULT_MODELS = {
   openai:     { envVar: "OPENAI_MODEL",     fallback: "gpt-4o-mini",              name: "GPT-4o-mini" },
   google:     { envVar: "GOOGLE_MODEL",     fallback: "gemini-2.5-flash",         name: "Gemini 2.5 Flash" },
   openrouter: { envVar: "OPENROUTER_MODEL", fallback: "openrouter/auto",          name: "OpenRouter" },
+  openai_compatible: { envVar: "OPENAI_COMPATIBLE_MODEL", fallback: "gpt-4o-mini", name: "OpenAI-compatible" },
 };
 
 // OpenRouter base URL — overridable for self-hosted proxies.
@@ -108,6 +111,16 @@ function getCloudName(provider) {
   return model !== cfg.fallback ? model : cfg.name;
 }
 
+
+
+function isCompatProvider(provider) {
+  return typeof provider === "string" && provider.startsWith("compat:");
+}
+
+function getCompatConfig(provider) {
+  return isCompatProvider(provider) ? apiKeyRepo.get(provider) : null;
+}
+
 // Auto-detect order for cloud providers
 const CLOUD_DETECT_ORDER = ["anthropic", "openai", "google", "openrouter"];
 
@@ -120,6 +133,10 @@ const CLOUD_DETECT_ORDER = ["anthropic", "openai", "google", "openrouter"];
  * @param {string} key      - The API key string, or `""` to deactivate.
  */
 export function setRuntimeKey(provider, key) {
+  if (isCompatProvider(provider)) {
+    const compat = getCompatConfig(provider);
+    return !!(compat?.apiKey && compat?.baseUrl && compat?.model);
+  }
   const envName = CLOUD_KEY_MAP[provider];
   if (!envName) return;
   runtimeKeys[envName] = key;
@@ -245,6 +262,10 @@ function isProviderUsable(provider) {
   if (provider === "local") {
     return !runtimeOllamaDisabled;
   }
+  if (isCompatProvider(provider)) {
+    const compat = getCompatConfig(provider);
+    return !!(compat?.apiKey && compat?.baseUrl && compat?.model);
+  }
   const envName = CLOUD_KEY_MAP[provider];
   if (!envName) return false;
   // Runtime key of "" means explicitly cleared — respect that
@@ -356,6 +377,7 @@ export function getConfiguredKeys() {
   // True only when Ollama has explicit config AND is not disabled — prevents
   // the dropdown from showing Ollama as "saved" when it's just the default URL.
   result.ollamaConfigured = !runtimeOllamaDisabled && hasOllamaConfig();
+  result.compatProviders = apiKeyRepo.listCompatSlots().map((provider) => ({ provider, ...(apiKeyRepo.get(provider) || {}) })).map((p)=>({ provider: p.provider, displayName: p.displayName || p.provider.replace("compat:",""), baseUrl: p.baseUrl || "", model: p.model || "", apiKey: maskKey(p.apiKey || "") }));
   return result;
 }
 
@@ -406,8 +428,12 @@ export function loadKeysFromDatabase() {
           runtimeOllamaDisabled = false;
           loaded += 1;
         }
-      } else {
-        const envName = CLOUD_KEY_MAP[provider];
+      } else if (!isCompatProvider(provider)) {
+        if (isCompatProvider(provider)) {
+    const compat = getCompatConfig(provider);
+    return !!(compat?.apiKey && compat?.baseUrl && compat?.model);
+  }
+  const envName = CLOUD_KEY_MAP[provider];
         if (!envName) continue;
         // Only restore from DB when the env var is absent and cache is not already
         // populated — env vars always win.
@@ -851,6 +877,20 @@ async function callProvider(provider, promptOrMessages, maxTokens, signal, respo
     }, "Anthropic");
   }
 
+
+  if (provider === "openai_compatible" || isCompatProvider(provider)) {
+    const compat = isCompatProvider(provider) ? getCompatConfig(provider) : null;
+    const apiKey = compat?.apiKey || getKey(CLOUD_KEY_MAP.openai_compatible);
+    const baseURL = compat?.baseUrl;
+    const model = compat?.model || getCloudModel("openai_compatible");
+    if (baseURL) validateUrl(baseURL);
+    const client = new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) });
+    const { system, user } = normaliseMessages(promptOrMessages);
+    const messages = [ ...(system ? [{ role: "system", content: system }] : []), { role: "user", content: user } ];
+    const resp = await withRetry(() => client.chat.completions.create({ model, messages, max_tokens: maxTokens || DEFAULT_MAX_TOKENS, ...(responseFormat ? { response_format: responseFormat } : {}), }, { signal }), provider);
+    return resp.choices?.[0]?.message?.content || "";
+  }
+
   if (provider === "openai") {
     const client = new OpenAI({ apiKey: getKey("OPENAI_API_KEY") });
     return await withRetry(async () => {
@@ -1125,6 +1165,20 @@ export async function streamText(promptOrMessages, onToken, options = {}) {
       if (tokensEmitted === 0 && isRetryableError(err)) return fallbackToNonStreaming(err);
       throw err;
     }
+  }
+
+
+  if (provider === "openai_compatible" || isCompatProvider(provider)) {
+    const compat = isCompatProvider(provider) ? getCompatConfig(provider) : null;
+    const apiKey = compat?.apiKey || getKey(CLOUD_KEY_MAP.openai_compatible);
+    const baseURL = compat?.baseUrl;
+    const model = compat?.model || getCloudModel("openai_compatible");
+    if (baseURL) validateUrl(baseURL);
+    const client = new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) });
+    const { system, user } = normaliseMessages(promptOrMessages);
+    const messages = [ ...(system ? [{ role: "system", content: system }] : []), { role: "user", content: user } ];
+    const resp = await withRetry(() => client.chat.completions.create({ model, messages, max_tokens: maxTokens || DEFAULT_MAX_TOKENS, ...(responseFormat ? { response_format: responseFormat } : {}), }, { signal }), provider);
+    return resp.choices?.[0]?.message?.content || "";
   }
 
   if (provider === "openai") {

--- a/backend/src/database/repositories/apiKeyRepo.js
+++ b/backend/src/database/repositories/apiKeyRepo.js
@@ -20,6 +20,7 @@ import { formatLogLine } from "../../utils/logFormatter.js";
 
 // Valid provider identifiers — mirrors CLOUD_KEY_MAP + local in aiProvider.js
 const VALID_PROVIDERS = ["anthropic", "openai", "google", "openrouter", "local"];
+const COMPAT_PREFIX = "compat:";
 
 /**
  * Encrypt a string value using the credential encryption utility.
@@ -66,7 +67,7 @@ function decryptValue(encryptedBlob) {
  * @throws {Error} If provider is not a recognised value.
  */
 export function set(provider, value) {
-  if (!VALID_PROVIDERS.includes(provider)) {
+  if (!VALID_PROVIDERS.includes(provider) && !isCompatProvider(provider)) {
     throw new Error(`[apiKeyRepo] Unknown provider: "${provider}"`);
   }
   const db = getDatabase();
@@ -93,7 +94,7 @@ export function get(provider) {
   if (!row) return null;
   const plaintext = decryptValue(row.value);
   if (!plaintext) return null;
-  if (provider === "local") {
+  if (provider === "local" || isCompatProvider(provider)) {
     try {
       return JSON.parse(plaintext);
     } catch {
@@ -131,4 +132,32 @@ export function getAll() {
     }
   }
   return result;
+}
+
+
+function isCompatProvider(provider) {
+  return typeof provider === "string" && provider.startsWith(COMPAT_PREFIX) && provider.length > COMPAT_PREFIX.length;
+}
+
+export function listCompatSlots() {
+  const db = getDatabase();
+  const rows = db.prepare("SELECT provider FROM api_keys WHERE provider LIKE 'compat:%' ORDER BY provider").all();
+  return rows.map((r) => r.provider);
+}
+
+export function getCompatSlot(slotId) {
+  const provider = slotId.startsWith(COMPAT_PREFIX) ? slotId : `${COMPAT_PREFIX}${slotId}`;
+  const value = get(provider);
+  if (!value || typeof value !== "object") return null;
+  return value;
+}
+
+export function setCompatSlot(slotId, config) {
+  const provider = slotId.startsWith(COMPAT_PREFIX) ? slotId : `${COMPAT_PREFIX}${slotId}`;
+  set(provider, config);
+}
+
+export function deleteCompatSlot(slotId) {
+  const provider = slotId.startsWith(COMPAT_PREFIX) ? slotId : `${COMPAT_PREFIX}${slotId}`;
+  remove(provider);
 }

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -66,7 +66,8 @@ router.post("/settings", requireRole("admin"), (req, res) => {
   // active-provider override — no key is written or validated.
   if (apiKey === "__use_existing__" && provider !== "local") {
     const configured = getConfiguredKeys();
-    if (!configured[provider]) {
+    const hasCompat = isCompat && configured.compatProviders?.some((p) => p.provider === provider);
+    if (!configured[provider] && !hasCompat) {
       return res.status(400).json({ error: `No saved key for "${provider}". Add a key in Settings first.` });
     }
     setActiveProvider(provider);

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -18,6 +18,8 @@ import { hasProvider, setRuntimeKey, setRuntimeOllama, setActiveProvider, checkO
 import { actor } from "../utils/actor.js";
 import { requireRole } from "../middleware/requireRole.js";
 import { isDemoEnabled, getDemoQuotaStatus } from "../middleware/demoQuota.js";
+import { validateUrl } from "../utils/ssrfGuard.js";
+import * as apiKeyRepo from "../database/repositories/apiKeyRepo.js";
 
 const router = Router();
 
@@ -53,8 +55,9 @@ router.get("/settings", requireRole("admin"), (req, res) => {
 router.post("/settings", requireRole("admin"), (req, res) => {
   const { provider, apiKey, baseUrl, model } = req.body;
   const validProviders = ["anthropic", "openai", "google", "openrouter", "local"];
+  const isCompat = typeof provider === "string" && provider.startsWith("compat:");
 
-  if (!provider || !validProviders.includes(provider)) {
+  if (!provider || (!validProviders.includes(provider) && !isCompat)) {
     return res.status(400).json({ error: `provider must be one of: ${validProviders.join(", ")}` });
   }
 
@@ -76,6 +79,20 @@ router.post("/settings", requireRole("admin"), (req, res) => {
     });
   }
 
+
+  if (isCompat) {
+    const normalizedBaseUrl = (baseUrl || "").trim();
+    const normalizedModel = (model || "").trim();
+    const normalizedApiKey = (apiKey || "").trim();
+    if (!normalizedBaseUrl) return res.status(400).json({ error: "baseUrl is required for compat providers" });
+    if (!normalizedModel) return res.status(400).json({ error: "model is required for compat providers" });
+    if (!normalizedApiKey || normalizedApiKey.length < 10) return res.status(400).json({ error: "apiKey is required and must be at least 10 characters" });
+    try { validateUrl(normalizedBaseUrl); } catch (err) { return res.status(400).json({ error: err.message }); }
+    apiKeyRepo.setCompatSlot(provider, { baseUrl: normalizedBaseUrl, model: normalizedModel, apiKey: normalizedApiKey, displayName: (req.body.displayName || provider.replace("compat:", "")).trim() });
+    setActiveProvider(provider);
+    logActivity({ ...actor(req), type: "settings.update", detail: `Compat provider configured: ${provider}` });
+    return res.json({ ok: true, provider, providerName: req.body.displayName || provider });
+  }
   if (provider === "local") {
     if (baseUrl && baseUrl.trim()) {
       let parsedUrl;
@@ -130,7 +147,8 @@ router.post("/settings", requireRole("admin"), (req, res) => {
 router.delete("/settings/:provider", requireRole("admin"), (req, res) => {
   const { provider } = req.params;
   const validProviders = ["anthropic", "openai", "google", "openrouter", "local"];
-  if (!validProviders.includes(provider)) {
+  const isCompat = typeof provider === "string" && provider.startsWith("compat:");
+  if (!validProviders.includes(provider) && !isCompat) {
     return res.status(400).json({ error: `provider must be one of: ${validProviders.join(", ")}` });
   }
 
@@ -138,8 +156,11 @@ router.delete("/settings/:provider", requireRole("admin"), (req, res) => {
   // getProvider() checks the runtimeActiveProvider override first.
   const wasActive = getProvider();
 
+
   if (provider === "local") {
     setRuntimeOllama({ baseUrl: "", model: "", disabled: true });
+  } else if (isCompat) {
+    apiKeyRepo.deleteCompatSlot(provider);
   } else {
     setRuntimeKey(provider, "");
   }

--- a/backend/tests/openai-compat-provider.test.js
+++ b/backend/tests/openai-compat-provider.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isRateLimitError, isTransientServerError } from '../src/aiProvider.js';
+
+test('classifies auth errors as non-rate-limit/non-5xx', () => {
+  const err = new Error('Unauthorized');
+  err.status = 401;
+  assert.equal(isRateLimitError(err), false);
+  assert.equal(isTransientServerError(err), false);
+});
+
+test('classifies rate limits', () => {
+  const err = new Error('Too many requests');
+  err.status = 429;
+  assert.equal(isRateLimitError(err), true);
+});
+
+test('classifies 5xx as transient', () => {
+  const err = new Error('Service unavailable');
+  err.status = 503;
+  assert.equal(isTransientServerError(err), true);
+});

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -49,6 +49,7 @@ const files = [
   "tests/device-emulation.test.js",
   "tests/ai-fallback.test.js",
   "tests/openrouter-provider.test.js",
+  "tests/openai-compat-provider.test.js",
   "tests/api-versioning.test.js",
   "tests/robots-sitemap.test.js",
   "tests/openapi.test.js",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added AI-001: generic `openai_compatible` provider slots (`compat:<id>`) using the existing OpenAI SDK with configurable `baseUrl`, `apiKey`, `model`, and `displayName`, including SSRF validation and settings integration.
+
+
 ## [1.7.0] — 2026-05-08
 
 ### Added

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -585,9 +585,11 @@ export const api = {
    * @param {string|null} apiKey     - API key (null for Ollama).
    * @param {Object}      [ollamaOpts] - `{ baseUrl, model }` for local provider.
    */
-  saveApiKey: (provider, apiKey, ollamaOpts) =>
+  saveApiKey: (provider, apiKey, opts = {}) =>
     provider === "local"
-      ? req("POST", "/settings", { provider, ...ollamaOpts })
+      ? req("POST", "/settings", { provider, ...opts })
+      : provider?.startsWith("compat:")
+      ? req("POST", "/settings", { provider, apiKey, ...opts })
       : req("POST", "/settings", { provider, apiKey }),
   /** @param {string} provider - Remove API key or deactivate Ollama. */
   deleteApiKey: (provider) => req("DELETE", `/settings/${provider}`),

--- a/frontend/src/components/header/ProviderDropdown.jsx
+++ b/frontend/src/components/header/ProviderDropdown.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function ProviderDropdown({ providers = [], activeProvider, onSelect }) {
+  return (
+    <select className="input" value={activeProvider || ""} onChange={(e) => onSelect?.(e.target.value)}>
+      {providers.map((p) => (
+        <option key={p.id} value={p.id}>{p.name}</option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/components/layout/ProviderBadge.jsx
+++ b/frontend/src/components/layout/ProviderBadge.jsx
@@ -30,6 +30,10 @@ function getProviderInfo(config, id) {
 
 const ALL_IDS = ["anthropic", "openai", "google", "openrouter", "local"];
 
+function getCompatIds(settings) {
+  return (settings?.compatProviders || []).map((p) => p.provider);
+}
+
 // A provider is "saved" if getSettings() returns a non-empty masked key for it,
 // or (for Ollama) if the backend reports it as explicitly configured.
 function getSavedProviders(settings) {
@@ -40,6 +44,7 @@ function getSavedProviders(settings) {
   if (settings.google)     list.push("google");
   if (settings.openrouter) list.push("openrouter");
   if (settings.ollamaConfigured || settings.activeProvider === "local") list.push("local");
+  for (const compatId of getCompatIds(settings)) list.push(compatId);
   return list;
 }
 
@@ -136,7 +141,9 @@ export default function ProviderBadge({ style }) {
 
   const c      = PROVIDER_STYLES[config.provider] || PROVIDER_STYLES.openai;
   const saved  = getSavedProviders(settings);
-  const unsaved = ALL_IDS.filter(id => !saved.includes(id));
+  const compatIds = getCompatIds(settings);
+  const allSwitchable = [...ALL_IDS, ...compatIds];
+  const unsaved = allSwitchable.filter(id => !saved.includes(id));
 
   return (
     <div ref={ref} style={{ position: "relative", flexShrink: 0, ...style }}>
@@ -194,7 +201,7 @@ export default function ProviderBadge({ style }) {
           {saved.length > 0 && (
             <div style={{ padding: "4px 0" }}>
               {saved.map(id => {
-                const sty      = PROVIDER_STYLES[id];
+                const sty      = PROVIDER_STYLES[id] || PROVIDER_STYLES.openrouter;
                 const info     = getProviderInfo(config, id);
                 const isActive = config.provider === id;
                 const isBusy   = switching === id;
@@ -248,7 +255,7 @@ export default function ProviderBadge({ style }) {
                 Add provider
               </div>
               {unsaved.map(id => {
-                const sty  = PROVIDER_STYLES[id];
+                const sty  = PROVIDER_STYLES[id] || PROVIDER_STYLES.openrouter;
                 const info = getProviderInfo(config, id);
                 return (
                   <button key={id} onClick={() => { setOpen(false); navigate("/settings"); }}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -20,6 +20,8 @@ import { resetOnboarding, emitTourEvent } from "../hooks/useOnboarding.js";
 import usePageTitle from "../hooks/usePageTitle.js";
 import { useAuth } from "../context/AuthContext.jsx";
 
+const OPENAI_COMPAT_HINTS = ["https://api.deepseek.com/v1", "https://api.groq.com/openai/v1", "https://api.mistral.ai/v1", "https://api.x.ai/v1"];
+
 const PROVIDERS = [
   {
     id: "anthropic",

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1089,6 +1089,33 @@ export default function Settings() {
     await reload();
   }
 
+  const [compatForm, setCompatForm] = useState({ slotId: "", displayName: "", baseUrl: "", model: "", apiKey: "" });
+  const [compatSaving, setCompatSaving] = useState(false);
+  const [compatError, setCompatError] = useState("");
+
+  async function handleCompatSave(e) {
+    e.preventDefault();
+    setCompatError("");
+    const slot = compatForm.slotId.trim().toLowerCase();
+    if (!slot || !/^[a-z0-9_-]+$/.test(slot)) return setCompatError("Slot ID is required (letters, numbers, _ or -).");
+    if (!compatForm.baseUrl.trim() || !compatForm.model.trim() || !compatForm.apiKey.trim()) return setCompatError("baseUrl, model, and apiKey are required.");
+    setCompatSaving(true);
+    try {
+      await api.saveApiKey(`compat:${slot}`, compatForm.apiKey.trim(), {
+        baseUrl: compatForm.baseUrl.trim(),
+        model: compatForm.model.trim(),
+        displayName: compatForm.displayName.trim() || slot,
+      });
+      invalidateConfigCache();
+      await reload();
+      setCompatForm({ slotId: "", displayName: "", baseUrl: "", model: "", apiKey: "" });
+    } catch (err) {
+      setCompatError(err.message || "Failed to save provider.");
+    } finally {
+      setCompatSaving(false);
+    }
+  }
+
   return (
     <div className="fade-in page-container-md">
       <button className="btn btn-ghost btn-sm mb-lg" onClick={() => navigate(-1)}>
@@ -1185,6 +1212,33 @@ export default function Settings() {
             Keys saved here are stored in memory and will reset when the server restarts.
             For persistent configuration, see the deployment documentation.
           </div>
+        </div>
+      </div>
+
+      <div className="card-padded" style={{ marginTop: 16 }}>
+        <h3 style={{ marginBottom: 10 }}>OpenAI-compatible providers</h3>
+        <form onSubmit={handleCompatSave} style={{ display: "grid", gap: 8 }}>
+          <input className="input" placeholder="Slot id (e.g. deepseek)" value={compatForm.slotId} onChange={(e) => setCompatForm((s) => ({ ...s, slotId: e.target.value }))} />
+          <input className="input" placeholder="Display name" value={compatForm.displayName} onChange={(e) => setCompatForm((s) => ({ ...s, displayName: e.target.value }))} />
+          <input className="input" placeholder="Base URL" value={compatForm.baseUrl} onChange={(e) => setCompatForm((s) => ({ ...s, baseUrl: e.target.value }))} />
+          <input className="input" placeholder="Model" value={compatForm.model} onChange={(e) => setCompatForm((s) => ({ ...s, model: e.target.value }))} />
+          <input className="input" placeholder="API key" value={compatForm.apiKey} onChange={(e) => setCompatForm((s) => ({ ...s, apiKey: e.target.value }))} />
+          {compatError && <div className="text-sm" style={{ color: "var(--red)" }}>{compatError}</div>}
+          <button className="btn btn-primary btn-sm" disabled={compatSaving}>{compatSaving ? "Saving..." : "Save compat provider"}</button>
+        </form>
+        <div style={{ marginTop: 12, display: "grid", gap: 8 }}>
+          {(settings?.compatProviders || []).map((p) => (
+            <div key={p.provider} className="card-padded-sm" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <div>
+                <div className="font-semi">{p.displayName} <span className="text-mono text-sub">({p.provider})</span></div>
+                <div className="text-xs text-sub">{p.baseUrl} · {p.model} · {p.apiKey}</div>
+              </div>
+              <div style={{ display: "flex", gap: 6 }}>
+                <button className="btn btn-ghost btn-xs" onClick={() => setCompatForm({ slotId: p.provider.replace("compat:", ""), displayName: p.displayName || "", baseUrl: p.baseUrl || "", model: p.model || "", apiKey: "" })}>Edit</button>
+                <button className="btn btn-danger btn-xs" onClick={() => handleDelete(p.provider)}>Delete</button>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
       </>}


### PR DESCRIPTION
### Motivation

- Provide a single, reusable adapter for OpenAI-compatible vendors (DeepSeek, Groq, Mistral, xAI, Azure, self-hosted vLLM/LocalAI, etc.) without adding per-vendor SDKs or hand-rolled fetches.
- Preserve existing provider behaviour (Anthropic/Google/OpenAI/Ollama) while enabling BYO `baseUrl` + `apiKey` + `model` slots and enforcing SSRF validation on any user-supplied URLs.

### Description

- Implemented initial `openai_compatible` support in `backend/src/aiProvider.js` including: compat-slot detection, `CLOUD_KEY_MAP` / `CLOUD_DEFAULT_MODELS` extension, `getConfiguredKeys()` exposure of compat slots, `loadKeysFromDatabase()` handling, and an OpenAI-SDK-backed adapter path that passes `baseURL` through to `new OpenAI({ apiKey, baseURL })` with `validateUrl()` called on user URLs before use.
- Extended the API key repository at `backend/src/database/repositories/apiKeyRepo.js` to accept `compat:<id>` slot entries and added helpers `listCompatSlots()`, `getCompatSlot()`, `setCompatSlot()`, and `deleteCompatSlot()` while reusing the existing encrypted `api_keys` pattern.
- Added server-side settings integration in `backend/src/routes/settings.js` to accept `provider:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd84e5a3248326a1f224ba018f9530)