### PR TITLE
feat: add initial test fixture iteration support

### DIFF
--- a/backend/src/database/migrations/023_test_fixtures.sql
+++ b/backend/src/database/migrations/023_test_fixtures.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS test_fixtures (
+  testId TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  format TEXT NOT NULL CHECK (format IN ("csv", "json")),
+  rows TEXT NOT NULL,
+  createdAt TEXT NOT NULL,
+  PRIMARY KEY (testId, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_test_fixtures_testId ON test_fixtures(testId);

--- a/backend/src/database/repositories/testFixtureRepo.js
+++ b/backend/src/database/repositories/testFixtureRepo.js
@@ -1,0 +1,27 @@
+import { getDatabase } from "../sqlite.js";
+
+function rowToFixture(row){
+  if(!row) return undefined;
+  return { ...row, rows: row.rows ? JSON.parse(row.rows) : [] };
+}
+
+export function upsertFixture({ testId, version, format, rows }) {
+  const db = getDatabase();
+  const createdAt = new Date().toISOString();
+  const payload = { testId, version, format, rows: JSON.stringify(rows || []), createdAt };
+  db.prepare(`INSERT INTO test_fixtures (testId, version, format, rows, createdAt)
+    VALUES (@testId, @version, @format, @rows, @createdAt)
+    ON CONFLICT(testId, version) DO UPDATE SET
+      format=excluded.format, rows=excluded.rows, createdAt=excluded.createdAt`).run(payload);
+  return getFixture(testId, version);
+}
+
+export function getFixture(testId, version){
+  const db=getDatabase();
+  return rowToFixture(db.prepare('SELECT * FROM test_fixtures WHERE testId=? AND version=?').get(testId, version));
+}
+
+export function listFixtures(testId){
+  const db=getDatabase();
+  return db.prepare('SELECT * FROM test_fixtures WHERE testId=? ORDER BY version DESC').all(testId).map(rowToFixture);
+}

--- a/backend/src/middleware/permissions.json
+++ b/backend/src/middleware/permissions.json
@@ -223,7 +223,7 @@
     "GET /api/v1/integrations/github/install/callback": {
       "role": "state_jwt (admin-issued)",
       "source": "backend/src/routes/integrations/github.js",
-      "noUi": "Auth via signed one-shot state JWT, NOT requireAuth — SameSite=Strict cookies are not sent on cross-site redirects from github.com. The state JWT is issued by GET /install/start (admin-gated) so the callback inherits admin authority transitively."
+      "noUi": "Auth via signed one-shot state JWT, NOT requireAuth \u2014 SameSite=Strict cookies are not sent on cross-site redirects from github.com. The state JWT is issued by GET /install/start (admin-gated) so the callback inherits admin authority transitively."
     },
     "POST /api/v1/integrations/github/app-webhook": {
       "role": "public (GitHub HMAC)",
@@ -233,7 +233,11 @@
     "POST /api/v1/projects/:id/trigger/github": {
       "role": "trigger_token + GitHub HMAC",
       "source": "backend/src/routes/trigger.js",
-      "noUi": "machine-only GitHub PR webhook [no-ui] — dual-auth (Bearer trigger token via requireTrigger + X-Hub-Signature-256 HMAC keyed by GITHUB_WEBHOOK_SECRET)"
+      "noUi": "machine-only GitHub PR webhook [no-ui] \u2014 dual-auth (Bearer trigger token via requireTrigger + X-Hub-Signature-256 HMAC keyed by GITHUB_WEBHOOK_SECRET)"
+    },
+    "POST /api/v1/tests/:testId/fixtures": {
+      "role": "qa_lead",
+      "source": "backend/src/routes/tests.js"
     }
   },
   "anyAuthenticatedMember": [
@@ -254,7 +258,8 @@
     "GET /api/v1/recycle-bin",
     "GET /api/v1/auth/export",
     "DELETE /api/v1/auth/account",
-    "POST /api/v1/chat"
+    "POST /api/v1/chat",
+    "GET /api/v1/tests/:testId/fixtures"
   ],
   "outOfScope": {
     "$comment": "Endpoints / flows present in code but not yet shipped end-to-end. Do NOT manually QA \u2014 file enhancement requests instead.",

--- a/backend/src/routes/tests.js
+++ b/backend/src/routes/tests.js
@@ -58,6 +58,7 @@ import { demoQuota } from "../middleware/demoQuota.js";
 import { actor } from "../utils/actor.js";
 import { requireRole } from "../middleware/requireRole.js";
 import * as baselineRepo from "../database/repositories/baselineRepo.js";
+import * as testFixtureRepo from "../database/repositories/testFixtureRepo.js";
 import { acceptBaseline } from "../runner/visualDiff.js";
 import { SHOTS_DIR, BASELINES_DIR, resolveBrowser, VIEWPORT_WIDTH, VIEWPORT_HEIGHT } from "../runner/config.js";
 import path from "path";
@@ -108,6 +109,26 @@ const parseTags = (raw) => {
  * @param {string} desiredName
  * @returns {string} A name that doesn't collide with any existing test.
  */
+
+
+function parseCsvRows(text) {
+  const lines = String(text || "").trim().split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) return [];
+  const headers = lines[0].split(",").map((h) => h.trim());
+  return lines.slice(1).map((line) => {
+    const cols = line.split(",");
+    const row = {};
+    headers.forEach((h, i) => { row[h] = (cols[i] || "").trim(); });
+    return row;
+  });
+}
+
+function clampIterationCap(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 10;
+  return Math.max(1, Math.min(100, Math.floor(n)));
+}
+
 function dedupeTestName(projectId, desiredName) {
   const base = String(desiredName || "").trim();
   if (!base) return base; // caller is responsible for never passing empty
@@ -210,6 +231,32 @@ router.get("/tests/:testId", (req, res) => {
 });
 
 // PATCH /api/tests/:testId — persist user-edited steps (and optionally other fields)
+
+router.get("/tests/:testId/fixtures", (req, res) => {
+  const test = testRepo.getById(req.params.testId);
+  if (!test) return res.status(404).json({ error: "not found" });
+  const project = projectRepo.getByIdInWorkspace(test.projectId, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
+  res.json(testFixtureRepo.listFixtures(test.id));
+});
+
+router.post("/tests/:testId/fixtures", requireRole("qa_lead"), (req, res) => {
+  const test = testRepo.getById(req.params.testId);
+  if (!test) return res.status(404).json({ error: "not found" });
+  const project = projectRepo.getByIdInWorkspace(test.projectId, req.workspaceId);
+  if (!project) return res.status(404).json({ error: "not found" });
+  const { format, rows, csvText, iterationCap } = req.body || {};
+  const cap = clampIterationCap(iterationCap ?? project.iterationCap);
+  let parsedRows = [];
+  if (format === "json") parsedRows = Array.isArray(rows) ? rows : [];
+  if (format === "csv") parsedRows = parseCsvRows(csvText);
+  if (!Array.isArray(parsedRows) || parsedRows.length === 0) return res.status(400).json({ error: "fixture rows required" });
+  const clampedRows = parsedRows.slice(0, cap);
+  const version = Number(test.codeVersion || 1);
+  const fixture = testFixtureRepo.upsertFixture({ testId: test.id, version, format, rows: clampedRows });
+  res.status(201).json({ ...fixture, capApplied: cap, truncated: parsedRows.length > clampedRows.length });
+});
+
 router.patch("/tests/:testId", requireRole("qa_lead"), async (req, res) => {
   const validationErr = validateTestUpdate(req.body);
   if (validationErr) return res.status(400).json({ error: validationErr });

--- a/backend/src/runner/executeTest.js
+++ b/backend/src/runner/executeTest.js
@@ -623,3 +623,21 @@ async function executeApiTest(test, runId, stepIndex, runStart) {
 
   return result;
 }
+
+
+export async function executeTestIterations(test, fixtureRows, runSingle) {
+  const rows = Array.isArray(fixtureRows) && fixtureRows.length ? fixtureRows : [null];
+  const out = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const iterTest = row
+      ? { ...test, playwrightCode: Object.entries(row).reduce((code, [k, v]) => String(code || "").replaceAll(`{{${k}}}`, String(v ?? "")), test.playwrightCode || "") }
+      : test;
+    const iterResult = await runSingle(iterTest);
+    iterResult.iterationIndex = row ? i : undefined;
+    if (row) iterResult.fixtureRow = row;
+    out.push(iterResult);
+    if (iterResult.status === "failed") break;
+  }
+  return out;
+}

--- a/backend/src/testRunner.js
+++ b/backend/src/testRunner.js
@@ -29,7 +29,7 @@
  */
 
 import { extractTestBody, isApiTest } from "./runner/codeParsing.js";
-import { executeTest } from "./runner/executeTest.js";
+import { executeTest, executeTestIterations } from "./runner/executeTest.js";
 import { runFeedbackLoop } from "./runner/feedbackIntegration.js";
 import { isSmokeTest } from "./pipeline/riskScorer.js";
 import { TRACES_DIR, DEFAULT_PARALLEL_WORKERS, MAX_TEST_RETRIES, launchBrowser, resolveBrowser, BROWSER_HEADLESS } from "./runner/config.js";
@@ -343,17 +343,15 @@ export async function runTests(project, tests, run, { parallelWorkers, browser: 
             logWarn(run, `↻ Retrying ${test.name} (attempt ${attempt + 1}/${MAX_TEST_RETRIES + 1})`);
           }
           const fixture = testFixtureRepo.getFixture(test.id, Number(test.codeVersion || 1));
-          const fixtureRows = Array.isArray(fixture?.rows) && fixture.rows.length ? fixture.rows : [null];
+          const iterResults = await executeTestIterations(
+            test,
+            fixture?.rows,
+            (iterTest) => executeTest(iterTest, browser, runId, i, runStart, { browser: resolvedBrowser, device, locale, timezoneId, geolocation, networkCondition }),
+          );
           let attemptResult = null;
-          for (let iterationIndex = 0; iterationIndex < fixtureRows.length; iterationIndex++) {
-            const fixtureRow = fixtureRows[iterationIndex];
-            const iterTest = fixtureRow ? { ...test, playwrightCode: Object.entries(fixtureRow).reduce((code, [k,v]) => String(code || "").replaceAll(`{{${k}}}`, String(v ?? "")), test.playwrightCode || "") } : test;
-            const iterResult = await executeTest(iterTest, browser, runId, i, runStart, { browser: resolvedBrowser, device, locale, timezoneId, geolocation, networkCondition });
-            iterResult.iterationIndex = fixtureRow ? iterationIndex : undefined;
-            if (fixtureRow) iterResult.fixtureRow = fixtureRow;
+          for (const iterResult of iterResults) {
             processResult(test, iterResult);
             attemptResult = iterResult;
-            if (iterResult.status === "failed") break;
           }
           if (attemptResult?.status === "failed") {
             const retryErr = new Error(attemptResult.error || "Test failed");

--- a/backend/src/testRunner.js
+++ b/backend/src/testRunner.js
@@ -41,6 +41,7 @@ import { classifyError } from "./utils/errorClassifier.js";
 import { structuredLog, formatLogLine } from "./utils/logFormatter.js";
 import * as testRepo from "./database/repositories/testRepo.js";
 import * as runRepo from "./database/repositories/runRepo.js";
+import * as testFixtureRepo from "./database/repositories/testFixtureRepo.js";
 import { signRunArtifacts, signArtifactUrl } from "./middleware/appSetup.js";
 import { writeArtifactBuffer } from "./utils/objectStorage.js";
 import fs from "fs";
@@ -341,7 +342,25 @@ export async function runTests(project, tests, run, { parallelWorkers, browser: 
           if (attempt > 0) {
             logWarn(run, `↻ Retrying ${test.name} (attempt ${attempt + 1}/${MAX_TEST_RETRIES + 1})`);
           }
-          const attemptResult = await executeTest(test, browser, runId, i, runStart, { browser: resolvedBrowser, device, locale, timezoneId, geolocation, networkCondition });
+          const fixture = testFixtureRepo.getFixture(test.id, Number(test.codeVersion || 1));
+          const fixtureRows = Array.isArray(fixture?.rows) && fixture.rows.length ? fixture.rows : [null];
+          let attemptResult = null;
+          for (let iterationIndex = 0; iterationIndex < fixtureRows.length; iterationIndex++) {
+            const fixtureRow = fixtureRows[iterationIndex];
+            const iterTest = fixtureRow ? { ...test, playwrightCode: Object.entries(fixtureRow).reduce((code, [k,v]) => String(code || "").replaceAll(`{{${k}}}`, String(v ?? "")), test.playwrightCode || "") } : test;
+            const iterResult = await executeTest(iterTest, browser, runId, i, runStart, { browser: resolvedBrowser, device, locale, timezoneId, geolocation, networkCondition });
+            iterResult.iterationIndex = fixtureRow ? iterationIndex : undefined;
+            if (fixtureRow) iterResult.fixtureRow = fixtureRow;
+            processResult(test, iterResult);
+            attemptResult = iterResult;
+            if (iterResult.status === "failed") break;
+          }
+          if (attemptResult?.status === "failed") {
+            const retryErr = new Error(attemptResult.error || "Test failed");
+            retryErr.result = attemptResult;
+            throw retryErr;
+          }
+          return attemptResult;
           if (attemptResult.status === "failed") {
             const retryErr = new Error(attemptResult.error || "Test failed");
             retryErr.result = attemptResult;
@@ -352,7 +371,6 @@ export async function runTests(project, tests, run, { parallelWorkers, browser: 
         result.retryCount = retryCount;
         result.failedAfterRetry = false;
         structuredLog("test.result", { runId, testId: test.id, status: result.status, durationMs: result.durationMs });
-        processResult(test, result);
       } catch (err) {
         // Build a synthetic result and route through processResult so SSE
         // `result` and `snapshot` events are emitted — otherwise the

--- a/backend/tests/fixture-iteration.test.js
+++ b/backend/tests/fixture-iteration.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getDatabase } from "../src/database/sqlite.js";
+import * as testFixtureRepo from "../src/database/repositories/testFixtureRepo.js";
+
+function resetFixtures() {
+  const db = getDatabase();
+  db.exec("DELETE FROM test_fixtures");
+}
+
+test("testFixtureRepo upsert/get round-trips JSON rows", () => {
+  resetFixtures();
+  const rows = [{ email: "a@example.com", role: "admin" }, { email: "b@example.com", role: "viewer" }];
+  const saved = testFixtureRepo.upsertFixture({ testId: "T-1", version: 1, format: "json", rows });
+  assert.equal(saved.testId, "T-1");
+  assert.equal(saved.version, 1);
+  assert.equal(saved.format, "json");
+  assert.deepEqual(saved.rows, rows);
+
+  const fetched = testFixtureRepo.getFixture("T-1", 1);
+  assert.deepEqual(fetched.rows, rows);
+});
+
+test("testFixtureRepo upsert replaces existing (testId, version)", () => {
+  resetFixtures();
+  testFixtureRepo.upsertFixture({ testId: "T-2", version: 3, format: "json", rows: [{ a: 1 }] });
+  testFixtureRepo.upsertFixture({ testId: "T-2", version: 3, format: "csv", rows: [{ a: 2 }, { a: 3 }] });
+  const all = testFixtureRepo.listFixtures("T-2");
+  assert.equal(all.length, 1);
+  assert.equal(all[0].format, "csv");
+  assert.deepEqual(all[0].rows, [{ a: 2 }, { a: 3 }]);
+});
+
+test("testFixtureRepo list returns newest version first", () => {
+  resetFixtures();
+  testFixtureRepo.upsertFixture({ testId: "T-3", version: 1, format: "json", rows: [{ x: "v1" }] });
+  testFixtureRepo.upsertFixture({ testId: "T-3", version: 2, format: "json", rows: [{ x: "v2" }] });
+  const versions = testFixtureRepo.listFixtures("T-3").map((f) => f.version);
+  assert.deepEqual(versions, [2, 1]);
+});

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -88,6 +88,7 @@ const files = [
   "tests/impact-analysis.test.js",
   "tests/github-checks.test.js",
   "tests/github-install-callback.test.js",
+  "tests/fixture-iteration.test.js",
 ];
 
 let passed = 0;

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -404,3 +404,10 @@ Removes the cron schedule and cancels the running cron task.
 | Error | Reason |
 |---|---|
 | 404 | Project not found, or no schedule exists |
+
+
+### POST /api/v1/tests/:testId/fixtures
+Upload fixture data for a test version. Body: `{ format: "csv"|"json", csvText?: string, rows?: object[], iterationCap?: number }`.
+
+### GET /api/v1/tests/:testId/fixtures
+Returns fixture history for the test, newest version first.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Data-driven test fixtures: upload CSV/JSON fixture rows per test version and execute per-row iterations with `iterationIndex` + row snapshot on run results.
+
 ## [1.7.1] — 2026-05-13
 
 ### Security

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -256,6 +256,10 @@ export const api = {
   getTest:      (testId)            => req("GET",    `/tests/${testId}`),
   /** @param {string} testId @param {Object} data - Fields to update. */
   updateTest:   (testId, data)      => req("PATCH",  `/tests/${testId}`, data),
+
+  uploadTestFixture: (testId, payload) => req("POST", `/tests/${testId}/fixtures`, payload),
+  getTestFixtures: (testId) => req("GET", `/tests/${testId}/fixtures`),
+
   /** @param {string} projectId @param {Object} data - `{ name, steps }`. Saved as Draft. */
   createTest:   (projectId, data)   => req("POST",   `/projects/${projectId}/tests`, data),
   /**


### PR DESCRIPTION
### Motivation
- Implement the CAP-001 groundwork to enable data-driven test iterations (CSV/JSON fixtures) so a single Playwright test can execute N iterations from a fixture and surface per-row attribution. 
- Provide server-side storage of per-test fixtures keyed by `(testId, version)` and a minimal API surface for upload + listing. 
- Add runner plumbing to iterate fixture rows, substitute `{{placeholder}}` tokens, and attach `iterationIndex` + row snapshot to result payloads for failure attribution.

### Description
- Added DB migration `023_test_fixtures.sql` creating `test_fixtures(testId, version, format, rows, createdAt)` and an index on `testId`. 
- New repository `backend/src/database/repositories/testFixtureRepo.js` with `upsertFixture`, `getFixture`, and `listFixtures` that round-trip `rows` as JSON. 
- Exposed endpoints in `backend/src/routes/tests.js`: `POST /api/v1/tests/:testId/fixtures` (gated to `qa_lead`) and `GET /api/v1/tests/:testId/fixtures` (workspace-authenticated), including CSV parsing and server-side iteration-cap clamping (default 10, max 100). 
- Extended runner flow in `backend/src/testRunner.js` to load the fixture for the test version, iterate over rows (or run once when no fixture), perform `{{field}}` substitutions into `playwrightCode`, execute each iteration, call `processResult` per-iteration, and annotate results with `iterationIndex` and `fixtureRow`. 
- Added client helpers in `frontend/src/api.js`: `uploadTestFixture(testId, payload)` and `getTestFixtures(testId)`. 
- Updated `backend/src/middleware/permissions.json`, `docs/api/projects.md`, and `docs/changelog.md` to document the new endpoints and permissions. 
- Small helper utilities added to `tests` routes: `parseCsvRows` and `clampIterationCap` for CSV parsing and iteration cap enforcement. 

### Testing
- Performed static syntax checks: `node --check backend/src/routes/tests.js`, `node --check backend/src/testRunner.js`, `node --check backend/src/database/repositories/testFixtureRepo.js`, and `node --check frontend/src/api.js`; all checks passed. 
- No new unit/integration tests for fixture iteration were added in this change (UI rendering updates and dedicated backend integration tests remain to be implemented in follow-up work).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048f6bbdf083268d2961eedf324b9a)