### PR TITLE
feat: add root cause failure clustering to run detail

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -1624,3 +1624,5 @@ A release is QA-approved only when **all** of the following are true:
 - Do NOT report a bug without a build/commit SHA and browser+OS.
 - Do NOT file duplicates of Known Issues.
 - Do NOT mark a flow as passing until **every** expected result is observed.
+
+- Run Detail root cause checks: verify panel appears when `rootCauses.length >= 1`; defaults collapsed for single cluster; auto-expands for 2+ clusters.

--- a/backend/src/database/migrations/027_run_root_causes.sql
+++ b/backend/src/database/migrations/027_run_root_causes.sql
@@ -1,0 +1,2 @@
+-- AUTO-010: persist deterministic root-cause clustering output for run failures
+ALTER TABLE runs ADD COLUMN rootCauses TEXT;

--- a/backend/src/database/repositories/runRepo.js
+++ b/backend/src/database/repositories/runRepo.js
@@ -38,6 +38,7 @@ const JSON_FIELDS = [
   "changedFiles", "impactAnalysis", // AUTO-004: git-diff impact analysis summary
   "githubCheck", // INT-002: GitHub Check Run metadata
   "tracePaths", // CAP-002 Phase 2: per-shard trace zip paths (migration 026)
+  "rootCauses", // AUTO-010: deterministic root-cause clustering output (migration 027)
 ];
 
 function rowToRun(row) {
@@ -96,6 +97,7 @@ const INSERT_COLS = [
   "environmentId", // DIF-012: optional project environment scope (migration 024)
   "shardCount", "shardsCompleted", // CAP-002: distributed shard telemetry (migration 025)
   "tracePaths", // CAP-002 Phase 2: per-shard trace zip paths (migration 026)
+  "rootCauses", // AUTO-010: deterministic root-cause clustering output (migration 027)
 ];
 
 const INSERT_SQL = `INSERT INTO runs (${INSERT_COLS.join(", ")})

--- a/backend/src/pipeline/failureClusterer.js
+++ b/backend/src/pipeline/failureClusterer.js
@@ -1,0 +1,84 @@
+/**
+ * @module pipeline/failureClusterer
+ * @description Deterministic run-failure clustering (no DB, no LLM calls).
+ */
+
+function normalizeText(value) {
+  return String(value || "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function getSourceUrl(result) {
+  const raw = result?.sourceUrl || result?.url || result?.step?.url || "";
+  if (!raw) return null;
+  try {
+    const u = new URL(raw);
+    const segs = u.pathname.split("/").filter(Boolean).slice(0, 1);
+    return `${u.origin}/${segs.join("/")}`.replace(/\/$/, "");
+  } catch {
+    return String(raw).split("?")[0].split("#")[0];
+  }
+}
+
+function getSelector(result) {
+  return normalizeText(result?.selector || result?.step?.selector || result?.failingSelector || "");
+}
+
+function normalizeError(error) {
+  return normalizeText(error)
+    .replace(/https?:\/\/[^\s)]+/g, "<url>")
+    .replace(/\b\d+\b/g, "<num>");
+}
+
+function editDistance(a, b) {
+  const aa = a || "";
+  const bb = b || "";
+  if (!aa || !bb) return Math.max(aa.length, bb.length);
+  const dp = Array.from({ length: aa.length + 1 }, () => new Array(bb.length + 1).fill(0));
+  for (let i = 0; i <= aa.length; i++) dp[i][0] = i;
+  for (let j = 0; j <= bb.length; j++) dp[0][j] = j;
+  for (let i = 1; i <= aa.length; i++) {
+    for (let j = 1; j <= bb.length; j++) {
+      const c = aa[i - 1] === bb[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + c);
+    }
+  }
+  return dp[aa.length][bb.length];
+}
+
+/** @param {{results?: Object[]}} input */
+export function clusterFailures({ results }) {
+  const rows = Array.isArray(results) ? results.filter((r) => r?.status === "failed") : [];
+  if (rows.length === 0) return [];
+
+  const clusters = [];
+  for (const row of rows) {
+    const errorPattern = normalizeError(row.error || row.message || "unknown_error");
+    const sharedUrl = getSourceUrl(row);
+    const sharedSelector = getSelector(row);
+
+    const existing = clusters.find((c) => {
+      if (c.errorPattern !== errorPattern) return false;
+      const sameUrl = c.sharedUrl === sharedUrl;
+      if (sameUrl) return true;
+      if (!c.sharedSelector || !sharedSelector) return false;
+      return editDistance(c.sharedSelector, sharedSelector) <= 4;
+    });
+
+    if (existing) {
+      existing.affectedTestIds.push(row.testId);
+      existing.size += 1;
+      continue;
+    }
+
+    clusters.push({
+      fingerprint: `${errorPattern}|${sharedUrl || ""}|${sharedSelector || ""}`,
+      affectedTestIds: [row.testId],
+      sharedUrl: sharedUrl || null,
+      sharedSelector: sharedSelector || null,
+      errorPattern,
+      size: 1,
+    });
+  }
+
+  return clusters.sort((a, b) => b.size - a.size);
+}

--- a/backend/src/testRunner.js
+++ b/backend/src/testRunner.js
@@ -32,6 +32,7 @@ import { extractTestBody, isApiTest } from "./runner/codeParsing.js";
 import { executeTest, executeTestIterations } from "./runner/executeTest.js";
 import { runFeedbackLoop } from "./runner/feedbackIntegration.js";
 import { isSmokeTest } from "./pipeline/riskScorer.js";
+import { clusterFailures } from "./pipeline/failureClusterer.js";
 import { TRACES_DIR, DEFAULT_PARALLEL_WORKERS, MAX_TEST_RETRIES, launchBrowser, resolveBrowser, BROWSER_HEADLESS } from "./runner/config.js";
 import { executeWithRetries } from "./runner/retry.js";
 import { finalizeRunIfNotAborted, isRunAborted } from "./utils/abortHelper.js";
@@ -771,6 +772,7 @@ export async function runTests(project, tests, run, { parallelWorkers, browser: 
 
   run.gateResult = evaluateQualityGates(project.qualityGates, run);
   run.webVitalsResult = evaluateWebVitalsBudgets(project.webVitalsBudgets, run);
+  run.rootCauses = clusterFailures({ results: run.results });
 
   // AUTO-017.3: persist per-run Web Vitals samples for MET-001 trend charts.
   // Best-effort only — telemetry failures must never fail the run.

--- a/backend/tests/failure-clusterer.test.js
+++ b/backend/tests/failure-clusterer.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { performance } from "node:perf_hooks";
+import { clusterFailures } from "../src/pipeline/failureClusterer.js";
+
+const same = Array.from({ length: 10 }, (_, i) => ({ testId: `T-${i}`, status: "failed", error: "Error: ECONNREFUSED https://api.example.com/auth", sourceUrl: "https://api.example.com/auth/login", selector: "#login-button" }));
+const c1 = clusterFailures({ results: same });
+assert.equal(c1.length, 1);
+assert.equal(c1[0].size, 10);
+
+const distinct = [
+  { testId: "a", status: "failed", error: "Error A", sourceUrl: "https://a.com/x" },
+  { testId: "b", status: "failed", error: "Error B", sourceUrl: "https://b.com/x" },
+];
+assert.equal(clusterFailures({ results: distinct }).length, 2);
+
+const urlPrefix = clusterFailures({ results: [
+  { testId: "u1", status: "failed", error: "Error A", sourceUrl: "https://app.example.com/auth/login" },
+  { testId: "u2", status: "failed", error: "Error A", sourceUrl: "https://app.example.com/auth/callback" },
+]});
+assert.equal(urlPrefix.length, 1);
+
+const selectorSimilar = clusterFailures({ results: [
+  { testId: "s1", status: "failed", error: "Error A", selector: "button[type='submit']" },
+  { testId: "s2", status: "failed", error: "Error A", selector: "button[type=submit]" },
+]});
+assert.equal(selectorSimilar.length, 1);
+
+assert.deepEqual(clusterFailures({ results: [{ testId: "p", status: "passed" }] }), []);
+
+const fixture = Array.from({ length: 100 }, (_, i) => ({ testId: `P-${i}`, status: "failed", error: `Error ${i % 8}`, sourceUrl: `https://a.example.com/path/${i % 4}` }));
+const start = performance.now();
+clusterFailures({ results: fixture });
+const elapsed = performance.now() - start;
+assert.ok(elapsed < 100, `expected <100ms, got ${elapsed}`);
+
+console.log("failure-clusterer.test.js passed");

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -98,6 +98,7 @@ const files = [
   "tests/run-shard-crash.test.js",
   "tests/run-shard-registry.test.js",
   "tests/run-shard-finalizer.test.js",
+  "tests/failure-clusterer.test.js",
 ];
 
 let passed = 0;

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -479,3 +479,5 @@ When provided, the run executes against the selected environment `baseUrl` only 
 **Finalization handoff:** the BullMQ shard whose `incrementShardsCompleted` UPDATE crosses the `shardCount` boundary is the single finalizer per run. It evaluates quality gates + Web Vitals against the full results array, runs the AI feedback loop exactly once, transitions status to `completed` via a first-writer-wins UPDATE that catches the late-abort race, emits the single `done` SSE event, and POSTs the optional `callbackUrl` for trigger-path runs. SQL row-locking is the linearization point — no JS-side mutex required.
 
 **CI/CD callbackUrl on sharded runs:** when `shards: N > 1` is combined with `callbackUrl` on a trigger run, the callback POSTs exactly once with the same payload shape as single-shard runs (`runId`, `status`, `passed`, `failed`, `total`, `error`, `gateResult`, `webVitalsResult`).
+
+- Added `run.rootCauses[]` to `GET /api/v1/runs/:runId` response: `{ fingerprint, affectedTestIds[], sharedUrl, sharedSelector, errorPattern, size }`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -534,3 +534,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added healing dashboard, metric samples primitives, and sprint promotion script scaffolding.
 
 <!-- promoted by script for PR #999; next=AUTO-017.3 -->
+
+- Added root-cause failure clustering summary on Run Detail and persisted `runs.rootCauses` for completed test runs.

--- a/frontend/src/pages/RunDetail.jsx
+++ b/frontend/src/pages/RunDetail.jsx
@@ -134,6 +134,7 @@ export default function RunDetail() {
   const [compareLoading, setCompareLoading] = useState(false);
   const [compareError, setCompareError] = useState(null);
   const [priorRuns, setPriorRuns] = useState([]);
+  const [rootCauseExpanded, setRootCauseExpanded] = useState(false);
   const { addNotification } = useNotifications();
 
   // Cap the streamed token buffer so long-running generation jobs don't
@@ -405,6 +406,11 @@ export default function RunDetail() {
   // verdict and the rendered pass rate will disagree on the same run.
   const passRateDenominator = Math.max(0, total - countNonExecutedSkips(results));
   const passRate = passRateDenominator > 0 ? Math.round((passed / passRateDenominator) * 100) : null;
+
+  const rootCauses = Array.isArray(run.rootCauses) ? run.rootCauses : [];
+  useEffect(() => {
+    setRootCauseExpanded(rootCauses.length >= 2);
+  }, [rootCauses.length, runId]);
 
   const traceUrl = run.tracePath ?? null;
   const traceViewerUrl = traceUrl ? `/trace-viewer/?trace=${encodeURIComponent(traceUrl)}` : null;
@@ -883,6 +889,23 @@ export default function RunDetail() {
               CI pipelines polling the trigger endpoint receive <code>gateResult.passed: false</code> and should exit non-zero.
             </div>
           </div>
+        </div>
+      )}
+
+      {/* ── Root cause summary (AUTO-010) ───────────────────────────────── */}
+      {run.type === "test_run" && rootCauses.length >= 1 && (
+        <div className="card" style={{ marginBottom: 16, padding: 12 }}>
+          <button className="btn btn-ghost btn-sm" onClick={() => setRootCauseExpanded((v) => !v)}>{rootCauseExpanded ? "▼" : "▶"} Root Cause Summary ({rootCauses.length})</button>
+          {rootCauseExpanded && (
+            <div style={{ display: "grid", gap: 8, marginTop: 10 }}>
+              {rootCauses.map((cluster) => (
+                <div key={cluster.fingerprint} className="card" style={{ padding: 10 }}>
+                  <div style={{ fontWeight: 600 }}>{cluster.errorPattern || "Likely root cause"}</div>
+                  <div style={{ fontSize: "0.82rem", color: "var(--text3)" }}>{cluster.size} affected test(s)</div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/tests/e2e/specs/run-detail-root-cause-ui.spec.mjs
+++ b/tests/e2e/specs/run-detail-root-cause-ui.spec.mjs
@@ -1,0 +1,26 @@
+import { test, expect } from "../utils/playwright.mjs";
+
+test("run detail renders root cause summary", async ({ page }) => {
+  const runId = "RUN-ROOT-1";
+  await page.route(`**/api/v1/runs/${runId}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        run: {
+          id: runId,
+          projectId: "PRJ-1",
+          type: "test_run",
+          status: "completed",
+          total: 2,
+          results: [],
+          rootCauses: [
+            { fingerprint: "a", errorPattern: "auth down", size: 2, affectedTestIds: ["TC-1", "TC-2"], sharedUrl: "https://api.example.com/auth", sharedSelector: "#login" },
+          ],
+        },
+      }),
+    });
+  });
+  await page.goto(`/runs/${runId}`);
+  await expect(page.getByText("Root Cause Summary")).toBeVisible();
+});


### PR DESCRIPTION
### Motivation
- Provide deterministic clustering of failing test results so a single outage (shared error, URL, or selector) surfaces as one root cause instead of many independent failures.
- Improve triage efficiency by surfacing `run.rootCauses` on completed test runs and in the Run Detail UI (AUTO-010 acceptance criteria).

### Description
- Added a pure clustering helper `backend/src/pipeline/failureClusterer.js` implementing error normalization, URL-prefix grouping, and selector-similarity via edit distance; it returns size-sorted clusters.
- Wired clustering into run finalization (`backend/src/testRunner.js`) so completed test runs persist `run.rootCauses`.
- Added migration `backend/src/database/migrations/027_run_root_causes.sql` and registered `rootCauses` in `backend/src/database/repositories/runRepo.js` JSON fields and insert columns for DB round-tripping.
- Implemented a Run Detail panel in `frontend/src/pages/RunDetail.jsx` that shows the Root Cause Summary above the test list, defaults collapsed for a single cluster, and auto-expands when there are 2+ clusters.
- Added unit tests `backend/tests/failure-clusterer.test.js` (registered in `backend/tests/run-tests.js`) and a Tier-3 E2E spec `tests/e2e/specs/run-detail-root-cause-ui.spec.mjs` that mocks the run payload.
- Updated `docs/api/projects.md`, `docs/changelog.md`, and `QA.md` to document the new `run.rootCauses[]` shape and manual checks.

### Testing
- Ran the new unit test `backend/tests/failure-clusterer.test.js` locally and it passed.
- Registered the test in the unified runner (`backend/tests/run-tests.js`); the full backend test suite was not executed in this environment.
- Added an E2E Playwright spec `tests/e2e/specs/run-detail-root-cause-ui.spec.mjs` that asserts the UI panel renders with a synthetic `rootCauses` payload (not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0610c233748326b9bf8df5b2d52b45)