### PR TITLE
feat(auth): add initial TOTP MFA enrollment and login verification

### DIFF
--- a/backend/src/database/migrations/015_mfa_columns.sql
+++ b/backend/src/database/migrations/015_mfa_columns.sql
@@ -1,0 +1,4 @@
+-- SEC-004: MFA columns on users table.
+ALTER TABLE users ADD COLUMN mfaSecret TEXT;
+ALTER TABLE users ADD COLUMN mfaEnabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN mfaRecoveryCodes TEXT;

--- a/backend/src/database/repositories/userRepo.js
+++ b/backend/src/database/repositories/userRepo.js
@@ -63,7 +63,7 @@ export function create(user) {
  */
 export function update(id, fields) {
   const db = getDatabase();
-  const allowed = ["name", "email", "passwordHash", "role", "avatar", "emailVerified", "updatedAt"];
+  const allowed = ["name", "email", "passwordHash", "role", "avatar", "emailVerified", "mfaSecret", "mfaEnabled", "mfaRecoveryCodes", "updatedAt"];
   const sets = [];
   const params = { id };
   for (const key of allowed) {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -43,6 +43,7 @@ import * as workspaceRepo from "../database/repositories/workspaceRepo.js";
 import * as accountRepo from "../database/repositories/accountRepo.js";
 import * as projectRepo from "../database/repositories/projectRepo.js";
 import { formatLogLine } from "../utils/logFormatter.js";
+import { encryptString, decryptString } from "../utils/credentialEncryption.js";
 import { stopSchedule } from "../scheduler.js";
 import { sendVerificationEmail } from "../utils/emailSender.js";
 import { buildJwtPayload, buildUserResponse } from "../utils/authWorkspace.js";
@@ -282,6 +283,76 @@ function ensureUserWorkspace(user) {
   workspaceRepo.create({ name: `${user.name || "My"}'s Workspace`, slug, ownerId: user.id });
 }
 
+
+const mfaPendingLogins = new Map();
+const MFA_LOGIN_TTL_MS = 5 * 60 * 1000;
+
+
+function base32Decode(input) {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const clean = String(input || "").toUpperCase().replace(/=+$/g, "").replace(/[^A-Z2-7]/g, "");
+  let bits = "";
+  for (const c of clean) {
+    const v = alphabet.indexOf(c);
+    if (v < 0) continue;
+    bits += v.toString(2).padStart(5, "0");
+  }
+  const out = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) out.push(parseInt(bits.slice(i, i + 8), 2));
+  return Buffer.from(out);
+}
+function generateTotpSecret() {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const bytes = crypto.randomBytes(20);
+  let out = "";
+  let bits = 0; let value = 0;
+  for (const b of bytes) {
+    value = (value << 8) | b;
+    bits += 8;
+    while (bits >= 5) { out += alphabet[(value >>> (bits - 5)) & 31]; bits -= 5; }
+  }
+  if (bits > 0) out += alphabet[(value << (5 - bits)) & 31];
+  return out;
+}
+function verifyTotp(token, secret, window = 1) {
+  const t = String(token || "").replace(/\s+/g, "");
+  if (!/^\d{6}$/.test(t)) return false;
+  const key = base32Decode(secret);
+  const step = 30;
+  const now = Math.floor(Date.now() / 1000 / step);
+  for (let w = -window; w <= window; w++) {
+    const counter = Buffer.alloc(8);
+    counter.writeBigUInt64BE(BigInt(now + w));
+    const hmac = crypto.createHmac("sha1", key).update(counter).digest();
+    const off = hmac[hmac.length - 1] & 0xf;
+    const code = ((hmac[off] & 0x7f) << 24) | ((hmac[off + 1] & 0xff) << 16) | ((hmac[off + 2] & 0xff) << 8) | (hmac[off + 3] & 0xff);
+    if (String(code % 1_000_000).padStart(6, "0") === t) return true;
+  }
+  return false;
+}
+
+function hashRecoveryCode(code) {
+  return crypto.createHash("sha256").update(String(code)).digest("hex");
+}
+
+function mintRecoveryCodes() {
+  const raw = Array.from({ length: 8 }, () => crypto.randomBytes(4).toString("hex"));
+  return { raw, hashed: raw.map(hashRecoveryCode) };
+}
+
+function createPendingMfaLogin(userId, workspaceId) {
+  const token = crypto.randomBytes(24).toString("base64url");
+  mfaPendingLogins.set(token, { userId, workspaceId, expiresAt: Date.now() + MFA_LOGIN_TTL_MS });
+  return token;
+}
+
+function consumePendingMfaLogin(token) {
+  const entry = mfaPendingLogins.get(token);
+  if (!entry) return null;
+  mfaPendingLogins.delete(token);
+  if (entry.expiresAt < Date.now()) return null;
+  return entry;
+}
 // ─── Routes ──────────────────────────────────────────────────────────────────
 
 /**
@@ -407,15 +478,17 @@ router.post("/login", async (req, res) => {
     // ACL-001: Ensure the user has a workspace before issuing a token.
     ensureUserWorkspace(user);
 
+    if (user.mfaEnabled === 1 && user.mfaSecret) {
+      const pendingToken = createPendingMfaLogin(user.id);
+      return res.status(200).json({ mfaRequired: true, pendingToken });
+    }
+
     const payload = buildJwtPayload(user);
     const token = signJwt(payload, getJwtSecret());
     const exp   = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
 
     setAuthCookie(res, token, exp);
 
-    // Note: token is NOT returned in the response body — it lives in the HttpOnly
-    // cookie only. The frontend reads user profile from this response and stores
-    // it in React state. The token_exp cookie exposes the expiry timestamp.
     return res.json({ user: buildUserResponse(user) });
   } catch (err) {
     console.error(formatLogLine("error", null, `[auth/login] ${err.message}`));
@@ -1024,5 +1097,71 @@ async function findOrCreateOAuthUser({ provider, providerId, email, name, avatar
 
   return user;
 }
+
+
+router.get("/mfa/status", requireAuth, (req, res) => {
+  const user = userRepo.getById(req.authUser.sub);
+  if (!user) return res.status(404).json({ error: "User not found." });
+  return res.json({ enabled: user.mfaEnabled === 1 });
+});
+
+router.post("/mfa/enroll", requireAuth, (req, res) => {
+  const user = userRepo.getById(req.authUser.sub);
+  if (!user) return res.status(404).json({ error: "User not found." });
+  const secret = generateTotpSecret();
+  const otpauth = `otpauth://totp/Sentri:${encodeURIComponent(user.email)}?secret=${secret}&issuer=Sentri&algorithm=SHA1&digits=6&period=30`;
+  userRepo.update(user.id, { mfaSecret: encryptString(secret), mfaEnabled: 0, updatedAt: new Date().toISOString() });
+  return res.json({ secret, otpauth });
+});
+
+router.post("/mfa/enable", requireAuth, (req, res) => {
+  const user = userRepo.getById(req.authUser.sub);
+  if (!user) return res.status(404).json({ error: "User not found." });
+  const secret = decryptString(user.mfaSecret);
+  if (!secret) return res.status(400).json({ error: "MFA enrollment is not initialized." });
+  const token = sanitiseString(req.body?.token, 16).replace(/\s+/g, "");
+  if (!verifyTotp(token, secret)) return res.status(400).json({ error: "Invalid code." });
+  const recovery = mintRecoveryCodes();
+  userRepo.update(user.id, { mfaEnabled: 1, mfaRecoveryCodes: JSON.stringify(recovery.hashed), updatedAt: new Date().toISOString() });
+  return res.json({ ok: true, recoveryCodes: recovery.raw });
+});
+
+router.post("/mfa/verify", async (req, res) => {
+  const pending = consumePendingMfaLogin(sanitiseString(req.body?.pendingToken, 200));
+  if (!pending) return res.status(401).json({ error: "MFA session expired. Sign in again." });
+  const user = userRepo.getById(pending.userId);
+  if (!user) return res.status(404).json({ error: "User not found." });
+  const token = sanitiseString(req.body?.token, 16).replace(/\s+/g, "");
+  const secret = decryptString(user.mfaSecret);
+  if (!secret) return res.status(400).json({ error: "MFA is not configured." });
+  let ok = verifyTotp(token, secret);
+  let updatedRecovery = null;
+  if (!ok && token) {
+    const hashed = hashRecoveryCode(token);
+    const codes = JSON.parse(user.mfaRecoveryCodes || "[]");
+    const idx = codes.indexOf(hashed);
+    if (idx >= 0) {
+      codes.splice(idx, 1);
+      updatedRecovery = JSON.stringify(codes);
+      ok = true;
+    }
+  }
+  if (!ok) return res.status(400).json({ error: "Invalid authentication code." });
+  if (updatedRecovery !== null) userRepo.update(user.id, { mfaRecoveryCodes: updatedRecovery, updatedAt: new Date().toISOString() });
+  const payload = buildJwtPayload(user);
+  const jwt = signJwt(payload, getJwtSecret());
+  const exp = Math.floor(Date.now() / 1000) + JWT_TTL_SEC;
+  setAuthCookie(res, jwt, exp);
+  return res.json({ user: buildUserResponse(user) });
+});
+
+router.post("/mfa/disable", requireAuth, async (req, res) => {
+  const user = userRepo.getById(req.authUser.sub);
+  if (!user) return res.status(404).json({ error: "User not found." });
+  const valid = await verifyAccountPassword(user, req.body?.password);
+  if (!valid) return res.status(403).json({ error: "Password confirmation failed." });
+  userRepo.update(user.id, { mfaEnabled: 0, mfaSecret: null, mfaRecoveryCodes: null, updatedAt: new Date().toISOString() });
+  return res.json({ ok: true });
+});
 
 export default router;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added initial MFA (TOTP) enrollment and login verification flow with recovery-code fallback endpoints and UI login challenge support.
+
+### Added
 - Scalable worker pool with dashboard metrics (queue depth, active/idle workers, job counts) when Redis/BullMQ is available; falls back to single-process mode automatically. (#9)
 - Recorder stealth mode: `stealth: true` option on recording sessions patches common headless-browser detection signals so sites that block automation render normally. No new dependencies. (#DIF-015c)
 - Recorder device profiles: select a device (iPhone 14, Pixel 7, iPad Pro, etc.) at session launch or mid-session; captured steps are preserved across device switches. (#DIF-015c)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -797,6 +797,12 @@ export const api = {
    */
   resendVerification: (email) => req("POST", "/auth/resend-verification", { email }),
 
+  mfaVerify: (pendingToken, token) => req("POST", "/auth/mfa/verify", { pendingToken, token }, TIMEOUT_DEFAULT, { skipUnauthorizedRedirect: true }),
+  mfaStatus: () => req("GET", "/auth/mfa/status"),
+  mfaEnroll: () => req("POST", "/auth/mfa/enroll"),
+  mfaEnable: (token) => req("POST", "/auth/mfa/enable", { token }),
+  mfaDisable: (password) => req("POST", "/auth/mfa/disable", { password }),
+
   // ── Account data portability / deletion (SEC-003) ───────────────────────────
   /**
    * Export account data as JSON. Password confirmation is required.

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -69,6 +69,8 @@ export default function Login() {
   const [tIdx, setTIdx] = useState(0);
   const [verifyEmail, setVerifyEmail] = useState(""); // SEC-001: email needing verification
   const [resending, setResending] = useState(false);
+  const [mfaPendingToken, setMfaPendingToken] = useState("");
+  const [mfaCode, setMfaCode] = useState("");
 
   const from = location.state?.from?.pathname || "/dashboard";
 
@@ -190,7 +192,21 @@ export default function Login() {
         }
         setMode("login"); setPassword(""); setConfirmPassword("");
       }
-      else login(data.user);
+      else if (data.mfaRequired && data.pendingToken) {
+        setMfaPendingToken(data.pendingToken);
+        setSuccess("Enter your authenticator code to finish sign in.");
+      } else login(data.user);
+    } catch (e) { setError(e.message); }
+    finally { setLoading(false); }
+  }
+
+  async function handleMfaVerify(e) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const data = await api.mfaVerify(mfaPendingToken, mfaCode);
+      login(data.user);
     } catch (e) { setError(e.message); }
     finally { setLoading(false); }
   }
@@ -212,6 +228,16 @@ export default function Login() {
       {/* Styles loaded from styles/pages/login.css */}
 
       <div className={`lp-root${mounted?" on":""}`}>
+        {mfaPendingToken && (
+          <div className="card" style={{position:"fixed",inset:0,background:"rgba(0,0,0,0.45)",display:"grid",placeItems:"center",zIndex:50}}>
+            <form onSubmit={handleMfaVerify} className="card" style={{padding:20,width:"min(420px,92vw)"}}>
+              <h3>Multi-factor verification</h3>
+              <p className="text-sub">Enter your 6-digit code or a recovery code.</p>
+              <input className="input" value={mfaCode} onChange={e=>setMfaCode(e.target.value)} placeholder="123456" />
+              <button className="btn btn-primary" style={{marginTop:12}} disabled={loading || !mfaCode.trim()}>{loading?"Verifying…":"Verify"}</button>
+            </form>
+          </div>
+        )}
 
         {/* LEFT */}
         <div className="lp-left">


### PR DESCRIPTION
### Motivation
- Add TOTP-based MFA so users can enroll an authenticator, verify at login, and use recovery codes to meet compliance and security requirements (SEC-004).
- Wire MFA into the existing auth flow so a JWT is not issued until the second factor is validated.

### Description
- Added DB migration `backend/src/database/migrations/015_mfa_columns.sql` to add `mfaSecret`, `mfaEnabled`, and `mfaRecoveryCodes` to the `users` table and updated `backend/src/database/repositories/userRepo.js` to allow updates to these fields.
- Implemented MFA logic in `backend/src/routes/auth.js`: in-process pending-MFA map, local TOTP generation/verification helpers (no external `otplib`), recovery-code hashing/consumption, and new endpoints `GET /auth/mfa/status`, `POST /auth/mfa/enroll`, `POST /auth/mfa/enable`, `POST /auth/mfa/verify`, and `POST /auth/mfa/disable` that encrypt the TOTP secret via `encryptString` and store hashed one-time recovery codes.
- Updated login flow to return `{ mfaRequired: true, pendingToken }` when a user has `mfaEnabled`, deferring JWT issuance until `/auth/mfa/verify` completes.
- Frontend changes: added API helpers in `frontend/src/api.js` (`mfaVerify`, `mfaStatus`, `mfaEnroll`, `mfaEnable`, `mfaDisable`) and updated `frontend/src/pages/Login.jsx` to present a simple modal for entering the TOTP or a recovery code and to complete the MFA verification flow.
- Documentation: added an unreleased changelog entry for MFA in `docs/changelog.md` and left follow-ups for tests and a Settings UI.

### Testing
- Ran `node --check backend/src/routes/auth.js` which passed with no syntax errors in the backend file.
- Attempted `node --check frontend/src/pages/Login.jsx` which cannot be syntax-checked directly in this environment due to `.jsx` extension handling, so frontend static verification was not completed here.
- Attempted `cd backend && npm install --package-lock-only` while experimenting with `otplib`, which failed with a registry `403` and the dependency was removed; no package changes remain in the final commit.
- No automated backend or integration tests were added in this change; adding backend tests for enroll/verify/recovery and registering them in `backend/tests/run-tests.js` is listed as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e44d7a74832681122499ebb63ff8)