### PR TITLE
fix(auth): bind MFA brute-force budget to pendingToken and harden related flows

### DIFF
--- a/backend/src/pipeline/domSanitizer.js
+++ b/backend/src/pipeline/domSanitizer.js
@@ -94,13 +94,23 @@ export function sanitizeDomSnapshot(input, ctxOrOpts = {}) {
     if (!text || typeof text !== "string") return text;
     let out = text;
     out = out.replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, (m) => allowMatch(m) ? m : (ctx.counters.email++, idFor(`email:${m.toLowerCase()}`, "EMAIL")));
-    out = out.replace(/\b(?:\+?\d{1,3}[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b/g, (m) => allowMatch(m) ? m : (ctx.counters.phone++, idFor(`phone:${m}`, "PHONE")));
-    out = out.replace(/\b\d{3}-\d{2}-\d{4}\b/g, (m) => allowMatch(m) ? m : (ctx.counters.ssn++, idFor(`ssn:${m}`, "SSN")));
+    // ORDERING: card + ssn MUST run before phone. The phone regex below
+    // accepts 10 digits with `[\s.-]` separators, and a canonical hyphenated
+    // PAN like "4111-1111-1111-1111" contains a phone-shaped 14-char prefix
+    // ("4111-1111-1111"). If phone ran first it would consume that prefix as
+    // <PHONE_n>, leaving "-1111" orphaned and the card regex unable to see a
+    // contiguous 13–19 digit run — Luhn never fires, the card counter stays
+    // zero, and the threat-model promise to redact cards silently fails.
+    // Card requires ≥13 digits so it cannot match phone-shaped input; SSN
+    // is `\d{3}-\d{2}-\d{4}` (2-digit middle) which cannot collide with
+    // phone's 3-digit middle group. Email is safe under any order (`@`).
     out = out.replace(/\b(?:\d[ -]*?){13,19}\b/g, (m) => {
       if (allowMatch(m) || !luhnValid(m)) return m;
       ctx.counters.card++;
       return idFor(`card:${m}`, "CARD");
     });
+    out = out.replace(/\b\d{3}-\d{2}-\d{4}\b/g, (m) => allowMatch(m) ? m : (ctx.counters.ssn++, idFor(`ssn:${m}`, "SSN")));
+    out = out.replace(/\b(?:\+?\d{1,3}[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b/g, (m) => allowMatch(m) ? m : (ctx.counters.phone++, idFor(`phone:${m}`, "PHONE")));
     out = out.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, (m) => allowMatch(m) ? m : (ctx.counters.jwt++, ctx.counters.token++, idFor(`jwt:${m}`, "TOKEN")));
     out = out.replace(/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+\/-]+=*\b/gi, (m) => allowMatch(m) ? m : (ctx.counters.bearer++, ctx.counters.token++, idFor(`auth:${m}`, "TOKEN")));
     out = out.replace(/([?&](?:token|code|access_token)=)([^&#\s]+)/gi, (_, p1, p2) => {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -631,6 +631,10 @@ export function _internalRevokeCurrentSession(req, res, auditMeta) {
  *     headers, return `false` (caller proceeds with cookie issue)
  *   - `allow` → no-op, return `false`
  *
+ * @param {Object} req  - SEC-007: forwarded to `logActivity` so the
+ *   `auth.mfa.enrollment_required` row captures `ipAddress` + `userAgent`.
+ *   Without it the row lands with both columns NULL, breaking SOC-2
+ *   session-reconstruction evidence.
  * @param {Object} res
  * @param {Object} user
  * @param {Object} auditMeta - Forwarded into the activity `meta` field
@@ -639,11 +643,12 @@ export function _internalRevokeCurrentSession(req, res, auditMeta) {
  * @returns {boolean} `true` when the request was already terminated with 403.
  * @private
  */
-function applyMfaEnforcement(res, user, auditMeta, auditDetail) {
+function applyMfaEnforcement(req, res, user, auditMeta, auditDetail) {
   const enforcement = evaluateMfaEnforcement(user);
   if (enforcement.state === "block") {
     logActivity({
       type: "auth.mfa.enrollment_required",
+      req,
       detail: auditDetail,
       userId: user.id, userName: user.name || user.email,
       workspaceId: enforcement.workspaceId,
@@ -823,7 +828,7 @@ router.post("/login", async (req, res) => {
     }
 
     // SEC-004: per-workspace MFA enforcement (block past grace, banner within).
-    if (applyMfaEnforcement(res, user, { method: "password" }, "Login blocked: workspace requires MFA.")) return;
+    if (applyMfaEnforcement(req, res, user, { method: "password" }, "Login blocked: workspace requires MFA.")) return;
 
     // SEC-004 §5c: tag password-only sessions with amr=["pwd"] so future
     // step-up auth checks can require MFA-asserted sessions explicitly.
@@ -993,16 +998,23 @@ router.post("/refresh", requireAuth, (req, res) => {
   const user = userRepo.getById(req.authUser.sub);
   if (!user) return res.status(401).json({ error: "User not found." });
 
-  // Revoke the old token
-  const { jti: oldJti, exp: oldExp } = req.authUser;
-  if (oldJti) revokedTokens.set(oldJti, oldExp);
-
   // SEC-004 §7: re-check workspace MFA enforcement on every refresh so a
   // policy change mid-session (admin enables mfaRequired with grace=0) is
   // enforced within one refresh cycle (~8h) rather than never. Without this,
   // a user whose session pre-dates the policy change stays logged in
   // indefinitely via the automatic refresh loop.
-  if (applyMfaEnforcement(res, user, { method: "refresh" }, "Session refresh blocked: workspace requires MFA.")) return;
+  //
+  // ORDERING: enforcement check MUST run BEFORE revoking the old token —
+  // otherwise a 403 `MFA_ENROLLMENT_REQUIRED` response leaves a revoked JTI
+  // in the cookie jar, and every subsequent authenticated request fails with
+  // a generic 401 "Session expired" instead of the actionable 403 the
+  // frontend uses to render the MFA enrollment panel. Mirrors the ordering
+  // in `/workspaces/switch` at routes/workspaces.js:152-170.
+  if (applyMfaEnforcement(req, res, user, { method: "refresh" }, "Session refresh blocked: workspace requires MFA.")) return;
+
+  // Revoke the old token only after enforcement passes
+  const { jti: oldJti, exp: oldExp } = req.authUser;
+  if (oldJti) revokedTokens.set(oldJti, oldExp);
 
   // Issue a fresh token with a new JTI (includes updated workspace context).
   // SEC-004 §5c: forward the existing `amr` claim so an MFA-asserted session
@@ -1327,7 +1339,7 @@ router.get("/github/callback", async (req, res) => {
 
     // SEC-004: enforcement applies to OAuth too. OAuth-only users have no
     // password but still need MFA when the workspace policy demands it.
-    if (applyMfaEnforcement(res, user, { method: "oauth", provider: "github" }, "OAuth login blocked: workspace requires MFA.")) return;
+    if (applyMfaEnforcement(req, res, user, { method: "oauth", provider: "github" }, "OAuth login blocked: workspace requires MFA.")) return;
 
     // SEC-004 §5c: OAuth sessions are tagged amr=["oauth"]. They are NOT
     // MFA-asserted — workspace MFA enforcement applies above.
@@ -1401,7 +1413,7 @@ router.get("/google/callback", async (req, res) => {
 
     // SEC-004: enforcement applies to OAuth too. OAuth-only users have no
     // password but still need MFA when the workspace policy demands it.
-    if (applyMfaEnforcement(res, user, { method: "oauth", provider: "google" }, "OAuth login blocked: workspace requires MFA.")) return;
+    if (applyMfaEnforcement(req, res, user, { method: "oauth", provider: "google" }, "OAuth login blocked: workspace requires MFA.")) return;
 
     // SEC-004 §5c: OAuth sessions are tagged amr=["oauth"]. They are NOT
     // MFA-asserted — workspace MFA enforcement applies above.

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1586,6 +1586,7 @@ router.post("/mfa/enroll", requireAuth, (req, res) => {
 
     logActivity({
       type: "auth.mfa.enroll_started",
+      req,
       detail: "Started TOTP enrollment.",
       userId: user.id, userName: user.name || user.email,
       workspaceId: req.authUser.workspaceId,
@@ -1638,6 +1639,7 @@ router.post("/mfa/enable", requireAuth, (req, res) => {
     if (!verifyTotp(token, secret)) {
       logActivity({
         type: "auth.mfa.verify_failed",
+        req,
         detail: "Invalid TOTP code during enable.",
         userId: user.id, userName: user.name || user.email,
         workspaceId: req.authUser.workspaceId,
@@ -1650,6 +1652,7 @@ router.post("/mfa/enable", requireAuth, (req, res) => {
 
     logActivity({
       type: "auth.mfa.enabled",
+      req,
       detail: "Enabled TOTP MFA.",
       userId: user.id, userName: user.name || user.email,
       workspaceId: req.authUser.workspaceId,
@@ -1775,6 +1778,7 @@ router.post("/mfa/verify", async (req, res) => {
     if (!ok) {
       logActivity({
         type: "auth.mfa.verify_failed",
+        req,
         detail: "Invalid MFA code during login.",
         userId: user.id, userName: user.name || user.email,
         workspaceId: pending.workspaceId,
@@ -1796,6 +1800,7 @@ router.post("/mfa/verify", async (req, res) => {
       userRepo.update(user.id, { mfaRecoveryCodes: updatedRecovery, updatedAt: new Date().toISOString() });
       logActivity({
         type: "auth.mfa.recovery_code_consumed",
+        req,
         detail: "Consumed a recovery code during MFA login.",
         userId: user.id, userName: user.name || user.email,
         workspaceId: pending.workspaceId,
@@ -1804,6 +1809,7 @@ router.post("/mfa/verify", async (req, res) => {
     } else {
       logActivity({
         type: "auth.mfa.login_verified",
+        req,
         detail: "MFA login verified.",
         userId: user.id, userName: user.name || user.email,
         workspaceId: pending.workspaceId,
@@ -1867,6 +1873,7 @@ router.post("/mfa/recovery-codes/regenerate", requireAuth, async (req, res) => {
 
     logActivity({
       type: "auth.mfa.recovery_codes_regenerated",
+      req,
       detail: "Regenerated MFA recovery codes.",
       userId: user.id, userName: user.name || user.email,
       workspaceId: req.authUser.workspaceId,
@@ -1936,6 +1943,7 @@ router.post("/mfa/disable", requireAuth, async (req, res) => {
 
     logActivity({
       type: "auth.mfa.disabled",
+      req,
       detail: "Disabled MFA.",
       userId: user.id, userName: user.name || user.email,
       workspaceId: req.authUser.workspaceId,

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -329,6 +329,17 @@ function ensureUserWorkspace(user) {
 const mfaPendingLogins = new Map();
 const MFA_LOGIN_TTL_MS = parseInt(process.env.MFA_PENDING_TTL_MS ?? "", 10) || 5 * 60 * 1000;
 
+// SEC-004 §5d: per-pendingToken attempt counter. The IP-based `mfaVerify`
+// limiter (5/15min) is necessary but not sufficient — an attacker rotating
+// source IPs has the full 5-minute MFA_LOGIN_TTL_MS window to brute-force
+// the 6-digit TOTP space (1M codes ≫ achievable on a botnet). Bind the
+// budget to the pendingToken so the entire MFA session is consumed after
+// `MFA_MAX_ATTEMPTS` failures regardless of IP — the attacker has to
+// re-prove the password to get a fresh token. Configurable in case a
+// deployment wants a tighter or looser ceiling; default 5 matches the
+// per-IP rate limiter.
+const MFA_MAX_ATTEMPTS = Math.max(1, parseInt(process.env.MFA_MAX_ATTEMPTS ?? "", 10) || 5);
+
 const _mfaPurgeInterval = setInterval(() => {
   const now = Date.now();
   for (const [k, v] of mfaPendingLogins) {
@@ -461,10 +472,27 @@ function hashRecoveryCode(code) {
 }
 
 /**
+ * SEC-004 §5b: maximum recovery-code list length used as the constant-time
+ * iteration ceiling. Must be ≥ the largest `MFA_RECOVERY_CODES_COUNT` any
+ * deployment could configure. Larger than the default (8) and any
+ * realistic admin-tuned value, so the scan iterates the same number of
+ * slots regardless of how many codes a particular user has remaining —
+ * preventing timing-based remaining-count exfiltration across users.
+ * @private
+ */
+const RECOVERY_CODE_SCAN_CEILING = 32;
+
+/**
  * Constant-time scan for a hashed recovery code in a list (SEC-004 §5b).
  * `indexOf` short-circuits on first match and leaks via timing which slot
  * matched. This iterates every entry regardless of outcome and only records
  * the first match.
+ *
+ * The loop iterates `RECOVERY_CODE_SCAN_CEILING` times — NOT `codes.length`
+ * — because the real list length is itself sensitive: a user with 1 code
+ * remaining produces a measurably faster scan than a user with 8, leaking
+ * recovery-code consumption across accounts. We pad with dummy hashes
+ * (zero-buffer compares) so total runtime is independent of `codes.length`.
  *
  * @param {string[]} codes  - Pre-hashed recovery codes (hex strings).
  * @param {string}   target - Pre-hashed candidate (hex string).
@@ -474,11 +502,19 @@ function hashRecoveryCode(code) {
 function findRecoveryCodeIndex(codes, target) {
   let matchIdx = -1;
   const targetBuf = Buffer.from(target);
-  for (let i = 0; i < codes.length; i++) {
-    const code = codes[i];
-    if (typeof code !== "string" || code.length !== target.length) continue;
+  // Dummy buffer for padding iterations — same length as target so
+  // timingSafeEqual does not throw and the dummy compare runs in the same
+  // time as a real compare. The dummy is all-zero ASCII; since target is a
+  // SHA-256 hex digest (lowercase hex characters), the timingSafeEqual will
+  // never spuriously match.
+  const dummyBuf = Buffer.alloc(target.length, 0x30 /* '0' */);
+  for (let i = 0; i < RECOVERY_CODE_SCAN_CEILING; i++) {
+    const code = i < codes.length ? codes[i] : null;
+    const candidate = (typeof code === "string" && code.length === target.length)
+      ? Buffer.from(code)
+      : dummyBuf;
     try {
-      if (crypto.timingSafeEqual(Buffer.from(code), targetBuf) && matchIdx < 0) {
+      if (crypto.timingSafeEqual(candidate, targetBuf) && matchIdx < 0 && candidate !== dummyBuf) {
         matchIdx = i;
       }
     } catch { /* length mismatch filtered above — unreachable */ }
@@ -515,8 +551,53 @@ function mintRecoveryCodes() {
  */
 function createPendingMfaLogin(userId, workspaceId) {
   const token = crypto.randomBytes(24).toString("base64url");
-  mfaPendingLogins.set(token, { userId, workspaceId, expiresAt: Date.now() + MFA_LOGIN_TTL_MS });
+  mfaPendingLogins.set(token, { userId, workspaceId, attempts: 0, expiresAt: Date.now() + MFA_LOGIN_TTL_MS });
   return token;
+}
+
+/**
+ * SEC-004 §5d: increment the per-pendingToken failure count. When the count
+ * reaches `MFA_MAX_ATTEMPTS` the token is consumed (deleted) so the attacker
+ * cannot continue submitting codes against it from a new IP. Caller decides
+ * how to respond — typically a 401 indistinguishable from "session expired"
+ * so the attacker cannot tell whether they exhausted attempts or simply hit
+ * an expired token.
+ *
+ * Exported for use by the WebAuthn flow which shares the same pendingToken
+ * and faces an identical brute-force window on assertion failures.
+ *
+ * @param {string} token
+ * @returns {{ exhausted: boolean, remaining: number } | null} `null` when the
+ *   token is missing/expired (caller treats as session-expired). Otherwise
+ *   `exhausted: true` when this attempt tipped the budget over the limit
+ *   (token has already been deleted), `false` when more attempts remain.
+ * @private
+ */
+function recordPendingMfaFailure(token) {
+  const entry = mfaPendingLogins.get(token);
+  if (!entry) return null;
+  if (entry.expiresAt < Date.now()) {
+    mfaPendingLogins.delete(token);
+    return null;
+  }
+  entry.attempts = (entry.attempts || 0) + 1;
+  if (entry.attempts >= MFA_MAX_ATTEMPTS) {
+    mfaPendingLogins.delete(token);
+    return { exhausted: true, remaining: 0 };
+  }
+  return { exhausted: false, remaining: MFA_MAX_ATTEMPTS - entry.attempts };
+}
+
+/**
+ * Internal cross-module helper — `routes/webauthn.js` shares the
+ * pendingToken brute-force surface (a stolen token can be replayed against
+ * arbitrary assertion attempts) and must apply the same per-token strike
+ * budget. Underscore prefix marks it as not part of the public API contract.
+ * @param {string} token
+ * @returns {{ exhausted: boolean, remaining: number } | null}
+ */
+export function _internalRecordPendingMfaFailure(token) {
+  return recordPendingMfaFailure(token);
 }
 
 /**
@@ -1776,17 +1857,32 @@ router.post("/mfa/verify", async (req, res) => {
     }
 
     if (!ok) {
+      // SEC-004 §5d: bump the per-pendingToken failure counter. The IP
+      // rate limiter (5/15min) doesn't bound an attacker who rotates IPs;
+      // the token-bound counter does. After `MFA_MAX_ATTEMPTS` failures
+      // the token is consumed and the user must re-enter password+email.
+      const strike = recordPendingMfaFailure(pendingTokenStr);
       logActivity({
         type: "auth.mfa.verify_failed",
         req,
-        detail: "Invalid MFA code during login.",
+        detail: strike?.exhausted
+          ? "Pending MFA token exhausted after repeated failures."
+          : "Invalid MFA code during login.",
         userId: user.id, userName: user.name || user.email,
         workspaceId: pending.workspaceId,
-        meta: { method: token ? "unknown" : "missing", phase: "login" },
+        meta: {
+          method: token ? "unknown" : "missing",
+          phase: "login",
+          remainingAttempts: strike?.remaining ?? null,
+          exhausted: strike?.exhausted || false,
+        },
       });
-      // Token is intentionally NOT consumed here — the rate limiter bounds
-      // brute force, and preserving the token lets the user retry without
-      // re-entering email+password after a typo.
+      if (strike?.exhausted) {
+        // Same 401 + message as the expired-token path so an attacker
+        // cannot distinguish "out of attempts" from "session expired" —
+        // both require re-running the password step to recover.
+        return res.status(401).json({ error: "MFA session expired. Sign in again." });
+      }
       return res.status(400).json({ error: "Invalid authentication code." });
     }
 

--- a/backend/src/routes/webauthn.js
+++ b/backend/src/routes/webauthn.js
@@ -287,6 +287,7 @@ router.post("/register/verify", requireAuth, async (req, res) => {
 
     logActivity({
       type: "auth.mfa.webauthn_registered",
+      req,
       detail: "Registered a WebAuthn credential.",
       userId: user.id, userName: user.name || user.email,
       workspaceId: req.authUser.workspaceId,
@@ -407,6 +408,7 @@ router.post("/authenticate/verify", async (req, res) => {
     if (!stored || stored.userId !== entry.userId) {
       logActivity({
         type: "auth.mfa.verify_failed",
+        req,
         detail: "WebAuthn assertion for unknown credential.",
         userId: entry.userId,
         workspaceId: entry.workspaceId,
@@ -436,6 +438,7 @@ router.post("/authenticate/verify", async (req, res) => {
     } catch (verifyErr) {
       logActivity({
         type: "auth.mfa.verify_failed",
+        req,
         detail: "WebAuthn assertion failed verification.",
         userId: entry.userId,
         workspaceId: entry.workspaceId,
@@ -457,6 +460,7 @@ router.post("/authenticate/verify", async (req, res) => {
     if (newCounter !== 0 && newCounter <= stored.counter) {
       logActivity({
         type: "auth.mfa.verify_failed",
+        req,
         detail: "WebAuthn clone detected — counter rollback.",
         userId: entry.userId,
         workspaceId: entry.workspaceId,
@@ -479,6 +483,7 @@ router.post("/authenticate/verify", async (req, res) => {
 
     logActivity({
       type: "auth.mfa.webauthn_verified",
+      req,
       detail: "WebAuthn login verified.",
       userId: user.id, userName: user.name || user.email,
       // SEC-004: attribute to the workspace snapshotted at /login time so the
@@ -583,6 +588,7 @@ router.delete("/credentials/:id", requireAuth, async (req, res) => {
 
     logActivity({
       type: "auth.mfa.webauthn_removed",
+      req,
       detail: "Removed a WebAuthn credential.",
       userId: user.id, userName: user.name || user.email,
       workspaceId: req.authUser.workspaceId,

--- a/backend/src/routes/webauthn.js
+++ b/backend/src/routes/webauthn.js
@@ -49,6 +49,7 @@ import {
   _internalCheckRateLimit,
   _internalVerifyAccountPassword,
   _internalRevokeCurrentSession,
+  _internalRecordPendingMfaFailure,
 } from "./auth.js";
 
 // ─── Lazy-loaded SimpleWebAuthn server module ─────────────────────────────────
@@ -406,14 +407,27 @@ router.post("/authenticate/verify", async (req, res) => {
 
     const stored = webauthnRepo.getById(credentialId);
     if (!stored || stored.userId !== entry.userId) {
+      // SEC-004 §5d: strike the shared pendingToken so the per-token
+      // budget applies to passkey brute force too (same threat as TOTP).
+      const strike = _internalRecordPendingMfaFailure(entry.pendingToken);
       logActivity({
         type: "auth.mfa.verify_failed",
         req,
-        detail: "WebAuthn assertion for unknown credential.",
+        detail: strike?.exhausted
+          ? "Pending MFA token exhausted after repeated WebAuthn failures."
+          : "WebAuthn assertion for unknown credential.",
         userId: entry.userId,
         workspaceId: entry.workspaceId,
-        meta: { method: "webauthn", reason: "unknown_credential" },
+        meta: {
+          method: "webauthn",
+          reason: "unknown_credential",
+          remainingAttempts: strike?.remaining ?? null,
+          exhausted: strike?.exhausted || false,
+        },
       });
+      if (strike?.exhausted) {
+        return res.status(401).json({ error: "MFA session expired. Sign in again." });
+      }
       return res.status(400).json({ error: "Unknown credential." });
     }
 
@@ -436,14 +450,27 @@ router.post("/authenticate/verify", async (req, res) => {
         },
       });
     } catch (verifyErr) {
+      // SEC-004 §5d: strike the shared pendingToken (see unknown_credential
+      // branch above for the threat-model rationale).
+      const strike = _internalRecordPendingMfaFailure(entry.pendingToken);
       logActivity({
         type: "auth.mfa.verify_failed",
         req,
-        detail: "WebAuthn assertion failed verification.",
+        detail: strike?.exhausted
+          ? "Pending MFA token exhausted after repeated WebAuthn failures."
+          : "WebAuthn assertion failed verification.",
         userId: entry.userId,
         workspaceId: entry.workspaceId,
-        meta: { method: "webauthn", reason: verifyErr.message },
+        meta: {
+          method: "webauthn",
+          reason: verifyErr.message,
+          remainingAttempts: strike?.remaining ?? null,
+          exhausted: strike?.exhausted || false,
+        },
       });
+      if (strike?.exhausted) {
+        return res.status(401).json({ error: "MFA session expired. Sign in again." });
+      }
       return res.status(400).json({ error: `Assertion failed: ${verifyErr.message}` });
     }
 

--- a/backend/src/routes/workspaces.js
+++ b/backend/src/routes/workspaces.js
@@ -96,6 +96,7 @@ router.patch("/current", requireRole("admin"), (req, res) => {
   if (mfaPolicyChanged) {
     logActivity({
       type: "workspace.mfa_policy_changed",
+      req,
       detail: `MFA enforcement ${ws.mfaRequired === 1 ? "enabled" : "disabled"} for workspace.`,
       userId: req.authUser.sub, userName: req.authUser.name || req.authUser.email,
       workspaceId: req.workspaceId,
@@ -160,6 +161,7 @@ router.post("/switch", (req, res) => {
   if (enforcement.state === "block") {
     logActivity({
       type: "auth.mfa.enrollment_required",
+      req,
       detail: "Workspace switch blocked: target workspace requires MFA.",
       userId: user.id, userName: user.name || user.email,
       workspaceId: enforcement.workspaceId,

--- a/backend/src/routes/workspaces.js
+++ b/backend/src/routes/workspaces.js
@@ -145,9 +145,16 @@ router.post("/switch", (req, res) => {
   const user = userRepo.getById(userId);
   if (!user) return res.status(401).json({ error: "User not found." });
 
-  // SEC-004 §11: re-check MFA enforcement when switching INTO a workspace
-  // whose policy may block the user. Without this, a user could switch into
-  // a workspace that requires MFA (past grace) and get a valid JWT for it.
+  // SEC-004 §11: re-check MFA enforcement on every workspace switch.
+  //
+  // Strictest-wins semantics: `evaluateMfaEnforcement(user)` inspects EVERY
+  // workspace the user belongs to (not just `targetId`) and returns the
+  // strictest outcome. This intentionally prevents a user from escaping
+  // enforcement by switching from a strict-MFA workspace into a no-MFA one
+  // — once any of their workspaces requires MFA past grace, they must
+  // enroll before any workspace switch succeeds. See the contract in
+  // `backend/src/utils/mfaEnforcement.js`.
+  //
   // Same pattern as the /refresh enforcement check in routes/auth.js.
   const enforcement = evaluateMfaEnforcement(user);
   if (enforcement.state === "block") {

--- a/backend/src/utils/activityLogger.js
+++ b/backend/src/utils/activityLogger.js
@@ -80,11 +80,31 @@ export function logActivity({ type, req, projectId, projectName, testId, testNam
   // dynamic import here keeps activityLogger's top-level dependency
   // graph minimal (the original notification dispatcher uses the same
   // dynamic-import pattern in routes/system.js for the replay path).
+  // SEC-007 SIEM dispatch contract:
+  //   - First write of an event → forwarded once with `count: 1`, `deduped: false`.
+  //   - Dedup hit (auth.login.failed burst, audit.read poll) → forwarded
+  //     again with the SAME `id`, incremented `count`, and `deduped: true`.
+  //     SIEM-side integrity verifiers that expect unique row ids must
+  //     dedupe on `(id, count)` or treat repeated ids as UPDATE events.
+  //     The alternative (suppress dispatch on dedup hits) would hide
+  //     credential-stuffing bursts — the live `count++` stream is the
+  //     attack signal a SOC analyst wants.
   if (activity.workspaceId) {
     setImmediate(() => {
       import("./notifications.js")
         .then((mod) => mod.dispatchSiemEvent?.(activity.workspaceId, activity))
-        .catch(() => { /* best-effort; row is already persisted */ });
+        .catch((err) => {
+          // SEC-007: best-effort SIEM forwarding — the row is already
+          // persisted, so a dispatch failure does not block the originating
+          // request. BUT a dynamic-import failure (module not found, syntax
+          // error in notifications.js, etc.) never reaches the DLQ —
+          // dispatchSiemEvent was never invoked. Surface to stderr so
+          // operators see persistent forwarding outages even when the DLQ
+          // counter stays at zero. Per-row failures (HTTP errors) are
+          // handled inside dispatchSiemEvent and land in audit_dlq.
+          console.error(formatLogLine("error", null,
+            `[activity/siem] SIEM dispatch failed for activity ${activity.id}: ${err?.message || err}`));
+        });
     });
   }
 


### PR DESCRIPTION
## Summary
Hardens authentication brute-force surfaces, fixes a PII-redaction ordering bug, corrects refresh-token revocation ordering, and improves SIEM dispatch observability. Also documents the actual (strictest-wins, all-workspaces) semantics of `evaluateMfaEnforcement` at the `/workspaces/switch` callsite so the comment no longer implies target-only enforcement.
## Motivation / Context
A handful of related correctness and security gaps surfaced while auditing the MFA login flow and the DOM sanitizer:
- **SEC-004 §5d — MFA brute force across rotated IPs.** The existing per-IP rate limiter (5/15min on `mfaVerify`) does not bound an attacker who rotates source IPs within the 5-minute `MFA_LOGIN_TTL_MS` window. The 6-digit TOTP space (1M codes) is tractable on a botnet against a single pending token. The same token is reused by the WebAuthn assertion flow, so the brute-force budget needs to be shared.
- **SEC-004 §5b — Recovery code scan timing leak.** The previous scan iterated `codes.length`, leaking how many recovery codes a user had remaining via response timing.
- **PII redaction ordering.** The phone regex ran before the card regex. A canonical hyphenated PAN (e.g. `4111-1111-1111-1111`) contains a phone-shaped 14-char prefix, so phone consumed it first, leaving the card regex unable to see a contiguous 13–19 digit run. Luhn never fired and the card counter stayed at zero — a silent failure of the threat-model promise to redact cards.
- **Refresh token revocation ordering.** The old JTI was revoked before MFA enforcement ran. A 403 `MFA_ENROLLMENT_REQUIRED` response then left a revoked JTI in the cookie jar, so every subsequent authenticated request returned a generic 401 "Session expired" instead of the actionable 403 the frontend uses to render the MFA enrollment panel.
- **SEC-007 — Audit log evidence + SIEM dispatch failures.** `applyMfaEnforcement` was not forwarding `req`, so `auth.mfa.enrollment_required` rows landed with NULL `ipAddress`/`userAgent`, breaking SOC-2 session reconstruction. Separately, dynamic-import failures in the SIEM forwarder never reached the DLQ and were silently swallowed.
- **`/workspaces/switch` comment.** The previous comment implied target-specific enforcement, but `evaluateMfaEnforcement` actually inspects every workspace the user belongs to and returns the strictest outcome. Documented the actual semantics so future readers don't try to "fix" it to be target-only.
## Linked issue
Closes #<!-- issue number -->
## Type of change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`, exists in ROADMAP.md)
- [ ] Breaking change (API, schema, or behavior incompatible with prior versions)
- [ ] Refactor / performance improvement (`refactor:` / `perf:`)
- [ ] Documentation / tests only (`docs:` / `test:`)
- [ ] Build / CI / chore (`build:` / `ci:` / `chore:`)
- [x] Security fix
## How to test
1. **MFA per-token brute force budget**
   - Start an MFA login to obtain a `pendingToken`.
   - From rotating source IPs (or with the IP rate limiter disabled in tests), submit `MFA_MAX_ATTEMPTS` (default 5) invalid TOTP codes against the same token.
   - Confirm the final response is `401 "MFA session expired. Sign in again."` and the token is no longer accepted even with a valid code. Re-running the password step must be required to proceed.
   - Repeat the same scenario against `/webauthn/assertion` — exhausting the budget on TOTP failures should also invalidate the token for WebAuthn (and vice versa).
2. **Recovery code timing safety**
   - Verify the scan iterates a constant `RECOVERY_CODE_SCAN_CEILING` (32) regardless of how many codes a user has remaining (e.g. log iteration count in a test).
3. **PII redaction ordering**
   - Feed `4111-1111-1111-1111` through the DOM sanitizer.
   - Confirm it is redacted as `<CARD_n>` (counter increments) and not as `<PHONE_n> + "-1111"`.
   - Confirm phone numbers and SSNs in the same payload still redact correctly.
4. **Refresh-token ordering**
   - Trigger a refresh for a user whose workspace requires MFA past grace and who has not enrolled.
   - Confirm response is `403 MFA_ENROLLMENT_REQUIRED` and the original access token is still usable (old JTI not revoked).
5. **Audit log evidence**
   - Trigger an `auth.mfa.enrollment_required` event via password login, refresh, and both OAuth providers.
   - Confirm the resulting activity rows have `ipAddress` and `userAgent` populated.
6. **SIEM dispatch failure surfacing**
   - Force a dynamic-import failure in `activityLogger`'s notifications path; confirm a `[activity/siem]` error line is written to stderr.
## Risk & rollback
- **Blast radius:** Auth-critical paths (login, refresh, OAuth callbacks, MFA verify, WebAuthn assertion, workspace switch). A regression here can lock legitimate users out or weaken brute-force protections.
- **Behavior changes visible to users:**
  - After `MFA_MAX_ATTEMPTS` (default 5) failed MFA/WebAuthn attempts against the same pending token, the user is told "MFA session expired" and must re-enter their password. This is intentional but tighter than before.
  - Refresh requests blocked by MFA enforcement no longer invalidate the existing access token.
- **Rollback:** Revert the PR. No schema migrations; all state is in-memory (`mfaPendingLogins`) or additive audit metadata. `MFA_MAX_ATTEMPTS` can also be raised via env var as a hot mitigation without a redeploy.
## Reviewer notes
- Please scrutinize the cross-module coupling between `backend/src/routes/auth.js` and `backend/src/routes/webauthn.js` via `_internalRecordPendingMfaFailure`. The underscore prefix marks it as not part of the public API; if a cleaner shared module is preferred, happy to extract.
- The `RECOVERY_CODE_SCAN_CEILING = 32` constant must remain ≥ any deployment's `MFA_RECOVERY_CODES_COUNT`. Worth a config-validation check on boot? (Follow-up.)
- The DOM sanitizer ordering comment is load-bearing — please don't reorder phone above card/ssn without re-reading it.
- The `/workspaces/switch` change is comment-only; the runtime behavior of `evaluateMfaEnforcement` is unchanged.
## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `perf:`, `docs:`, `refactor:`, `chore:`, etc.)
- [x] Branch is off `develop`, not `main`
- [ ] `cd backend && npm test` passes locally
- [ ] `cd frontend && npm run build && npm test` passes locally
- [ ] New/modified backend logic has tests registered in `backend/tests/run-tests.js`
- [ ] `docs/changelog.md` updated under `## [Unreleased]` (user-visible changes only)
- [ ] `QA.md` walked for affected flows; Golden E2E re-run if core flow was touched
- [ ] `permissions.json` updated if a `requireRole()` gate was added/changed — N/A, no role gates changed
- [x] No orphan backend routes (PROC-001) — no new routes added
- [ ] ROADMAP.md + NEXT.md updated if this closes a roadmap item (see REVIEW.md) — N/A
- [x] UI changes meet accessibility requirements — N/A, backend-only
- [x] No secrets, API keys, or credentials in the diff