### PR TITLE
feat(inf): INF-009 scaffold Helm chart, probes, and disaster recovery docs

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -1,0 +1,19 @@
+name: Helm Validate
+on:
+  pull_request:
+    paths:
+      - 'helm/**'
+      - '.github/workflows/helm-validate.yml'
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+      - run: helm template helm/sentri --values tests/helm/values-overrides.yaml > /tmp/rendered.yaml
+      - uses: yannh/kubeconform-action@v0.1.17
+        with:
+          kubernetes-version: "1.30.0"
+          schema-location: default
+          strict: true
+          files: /tmp/rendered.yaml

--- a/.github/workflows/nightly-backup.yml
+++ b/.github/workflows/nightly-backup.yml
@@ -12,8 +12,17 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
       - name: Upload daily backup
+        run: aws s3 cp backup.sql "s3://${S3_BACKUP_BUCKET}/daily/$(date -u +%F).sql"
+        env:
+          S3_BACKUP_BUCKET: ${{ secrets.S3_BACKUP_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_BACKUP_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_BACKUP_REGION }}
+      - name: Upload monthly backup snapshot
         run: |
-          aws s3 cp backup.sql "s3://${S3_BACKUP_BUCKET}/daily/$(date -u +%F).sql"
+          if [ "$(date -u +%d)" = "01" ]; then
+            aws s3 cp backup.sql "s3://${S3_BACKUP_BUCKET}/monthly/$(date -u +%Y-%m).sql"
+          fi
         env:
           S3_BACKUP_BUCKET: ${{ secrets.S3_BACKUP_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_BACKUP_ACCESS_KEY_ID }}

--- a/.github/workflows/nightly-backup.yml
+++ b/.github/workflows/nightly-backup.yml
@@ -1,0 +1,21 @@
+name: Nightly Postgres Backup
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump postgres
+        run: pg_dump "$DATABASE_URL" > backup.sql
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - name: Upload daily backup
+        run: |
+          aws s3 cp backup.sql "s3://${S3_BACKUP_BUCKET}/daily/$(date -u +%F).sql"
+        env:
+          S3_BACKUP_BUCKET: ${{ secrets.S3_BACKUP_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_BACKUP_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_BACKUP_REGION }}

--- a/QA.md
+++ b/QA.md
@@ -2061,3 +2061,10 @@ Once-per-release smoke. Pass all 8 sections before tagging.
 2. Run tests twice and verify dashboard Coverage section shows 30-day points.
 3. Verify project with coverage disabled shows empty-state prompt.
 4. Verify run coverage summary includes sourceMapStatus fallback when no sourcemaps.
+
+
+## Kubernetes deployment + DR (INF-009)
+- [ ] `helm template helm/sentri --set ingress.host=test.local` renders manifests.
+- [ ] Worker `/healthz` returns 200 when queue is connected and 503 on Redis outage.
+- [ ] Nightly backup workflow configured with S3 secrets and uploads snapshot artifacts.
+- [ ] DR runbook restore steps verified with `pg_restore`.

--- a/backend/src/middleware/appSetup.js
+++ b/backend/src/middleware/appSetup.js
@@ -222,6 +222,33 @@ app.get("/metrics", async (req, res) => {
   res.end(await metricsRegister.metrics());
 });
 
+
+// INF-009: Kubernetes-ready health endpoint used by readiness/liveness probes.
+// Returns 200 only when both database and Redis are reachable.
+app.get("/api/v1/health", async (_req, res) => {
+  const checks = { database: false, redis: false };
+
+  try {
+    const { getDatabase } = await import("../database/sqlite.js");
+    const db = getDatabase();
+    if (typeof db?.query === "function") {
+      await db.query("SELECT 1");
+    } else if (typeof db?.prepare === "function") {
+      db.prepare("SELECT 1").get();
+    }
+    checks.database = true;
+  } catch {
+    checks.database = false;
+  }
+
+  checks.redis = isRedisAvailable();
+
+  if (checks.database && checks.redis) {
+    return res.status(200).json({ ok: true, checks });
+  }
+  return res.status(503).json({ ok: false, checks });
+});
+
 // ─── Cross-origin cookie helper ──────────────────────────────────────────────
 // When the frontend and backend live on different origins (e.g. GitHub Pages +
 // Render), SameSite=Strict cookies are never sent on cross-site requests.

--- a/backend/src/worker.js
+++ b/backend/src/worker.js
@@ -17,6 +17,7 @@
  * rather than silently running no jobs).
  */
 import dotenv from "dotenv";
+import http from "http";
 import { getDatabase, closeDatabase } from "./database/sqlite.js";
 import { migrateFromJsonIfNeeded } from "./database/migrate.js";
 import { loadKeysFromDatabase } from "./aiProvider.js";
@@ -55,8 +56,24 @@ loadKeysFromDatabase();
 // 3. Workspace backfill — same one-shot as the web entry point.
 ensureDefaultWorkspaces();
 
+let _workerReady = false;
+
 // 4. Start the BullMQ Worker.
 startWorker();
+_workerReady = true;
+const healthPort = Number(process.env.WORKER_HEALTH_PORT || 3002);
+const healthServer = http.createServer((_req, res) => {
+  if (_workerReady) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+  res.writeHead(503, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: false }));
+});
+healthServer.listen(healthPort, () => {
+  console.log(formatLogLine("info", null, `[worker] health endpoint listening on :${healthPort}`));
+});
 
 console.log(formatLogLine("info", null,
   `[worker] Standalone worker process started (REDIS_URL configured, WORKER_CONCURRENCY=${process.env.WORKER_CONCURRENCY || process.env.MAX_WORKERS || 2})`));
@@ -71,6 +88,7 @@ async function gracefulShutdown(signal) {
     await stopWorker();
     await closeQueue();
     await closeRedis();
+    await new Promise((resolve) => healthServer.close(resolve));
     await closeDatabase();
     process.exit(0);
   } catch (err) {

--- a/backend/src/worker.js
+++ b/backend/src/worker.js
@@ -24,7 +24,7 @@ import { loadKeysFromDatabase } from "./aiProvider.js";
 import { ensureDefaultWorkspaces } from "./database/repositories/workspaceRepo.js";
 import { closeQueue } from "./queue.js";
 import { startWorker, stopWorker } from "./workers/runWorker.js";
-import { closeRedis } from "./utils/redisClient.js";
+import { closeRedis, isRedisAvailable } from "./utils/redisClient.js";
 import { formatLogLine } from "./utils/logFormatter.js";
 
 dotenv.config();
@@ -63,7 +63,7 @@ startWorker();
 _workerReady = true;
 const healthPort = Number(process.env.WORKER_HEALTH_PORT || 3002);
 const healthServer = http.createServer((_req, res) => {
-  if (_workerReady) {
+  if (_workerReady && isRedisAvailable()) {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ ok: true }));
     return;

--- a/backend/tests/health-routes.test.js
+++ b/backend/tests/health-routes.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { createTestContext } from "./helpers/test-base.js";
+
+const t = createTestContext();
+const runner = t.createTestRunner();
+
+async function main() {
+  const server = t.app.listen(0);
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  try {
+    await runner.test("GET /api/v1/health returns JSON shape", async () => {
+      const res = await fetch(`${base}/api/v1/health`);
+      assert.ok([200, 503].includes(res.status), `unexpected status: ${res.status}`);
+      const body = await res.json();
+      assert.equal(typeof body.ok, "boolean");
+      assert.equal(typeof body.checks, "object");
+      assert.equal(typeof body.checks.database, "boolean");
+      assert.equal(typeof body.checks.redis, "boolean");
+    });
+
+    await runner.test("GET /api/v1/health is 503 when Redis is unavailable", async () => {
+      const env = t.setupEnv({ REDIS_URL: "" });
+      try {
+        const res = await fetch(`${base}/api/v1/health`);
+        assert.equal(res.status, 503);
+        const body = await res.json();
+        assert.equal(body.ok, false);
+        assert.equal(body.checks.redis, false);
+      } finally {
+        env.restore();
+      }
+    });
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+
+  runner.summary("health-routes");
+}
+
+await main();

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -164,6 +164,7 @@ const files = [
   "tests/source-map-resolver.test.js",
   "tests/server-coverage-proxy.test.js", // AUTO-009h — server-side coverage capture for API tests
   "tests/observability.test.js",
+  "tests/health-routes.test.js",
   // AUTO-022 — AI eval harness scorer + regression-detection + metric_samples persistence.
   "tests/eval-pipeline.test.js",
   "tests/eval-regression.test.js",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- INF-009 scaffold: initial `helm/sentri` chart, worker `/healthz` endpoint, Helm validation workflow, nightly Postgres backup workflow, and Kubernetes/DR docs.
+
+
 ## [1.8.0] — 2026-05-21
 
 ### Breaking

--- a/docs/guide/disaster-recovery.md
+++ b/docs/guide/disaster-recovery.md
@@ -1,0 +1,17 @@
+# Disaster recovery (INF-009)
+
+- **RTO target:** <4 hours
+- **RPO target:** <24 hours
+
+## Backup layout
+- `s3://<bucket>/daily/YYYY-MM-DD.sql`
+- keep 30 daily and 12 monthly snapshots (bucket lifecycle policy)
+
+## Restore
+1. Provision fresh Postgres StatefulSet PVC.
+2. Download snapshot.
+3. Run: `pg_restore --clean --if-exists --no-owner --dbname "$DATABASE_URL" backup.sql`
+4. Restart Sentri backend/worker.
+
+## Rollback failed release
+- `helm rollback sentri <revision> --wait`

--- a/docs/guide/disaster-recovery.md
+++ b/docs/guide/disaster-recovery.md
@@ -5,6 +5,7 @@
 
 ## Backup layout
 - `s3://<bucket>/daily/YYYY-MM-DD.sql`
+- `s3://<bucket>/monthly/YYYY-MM.sql`
 - keep 30 daily and 12 monthly snapshots (bucket lifecycle policy)
 
 ## Restore

--- a/docs/guide/env-vars.md
+++ b/docs/guide/env-vars.md
@@ -358,3 +358,12 @@ Counter naming uses `app_*` rather than a product-name prefix so Prometheus dash
 | `VITE_SENTRY_TRACES_SAMPLE_RATE` | `0` | Fraction (0–1) of frontend transactions sampled for Sentry performance traces. Default `0` keeps Sentry to crash reporting + breadcrumbs only. |
 
 
+
+
+### Kubernetes + Backup
+
+- `WORKER_HEALTH_PORT`: Port for worker-local `/healthz` endpoint (default `3002`).
+- `S3_BACKUP_BUCKET`: S3 bucket for nightly database backups.
+- `S3_BACKUP_REGION`: Region for S3 backup bucket.
+- `S3_BACKUP_ACCESS_KEY_ID`: Access key used by backup workflow.
+- `S3_BACKUP_SECRET_ACCESS_KEY`: Secret key used by backup workflow.

--- a/docs/guide/kubernetes-deployment.md
+++ b/docs/guide/kubernetes-deployment.md
@@ -4,3 +4,9 @@
 2. `kubectl wait --for=condition=Ready pod -l app=backend --timeout=90s`
 3. `kubectl wait --for=condition=Ready pod -l app=worker --timeout=90s`
 4. Validate `GET /api/v1/health` and worker `/healthz`.
+
+
+## Services created by chart
+- `sentri-backend` (ClusterIP) for HTTP traffic and ingress backend target.
+- `sentri-postgres` (headless) for StatefulSet stable network identity.
+- `sentri-redis` (ClusterIP) for BullMQ queue connectivity.

--- a/docs/guide/kubernetes-deployment.md
+++ b/docs/guide/kubernetes-deployment.md
@@ -1,0 +1,6 @@
+# Kubernetes deployment
+
+1. `helm install sentri ./helm/sentri --set ingress.host=sentri.example.com`
+2. `kubectl wait --for=condition=Ready pod -l app=backend --timeout=90s`
+3. `kubectl wait --for=condition=Ready pod -l app=worker --timeout=90s`
+4. Validate `GET /api/v1/health` and worker `/healthz`.

--- a/helm/sentri/Chart.yaml
+++ b/helm/sentri/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sentri
+description: Sentri Kubernetes deployment chart
+version: 0.1.0
+appVersion: "latest"
+type: application

--- a/helm/sentri/templates/backend-deployment.yaml
+++ b/helm/sentri/templates/backend-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sentri-backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector: { matchLabels: { app: backend } }
+  template:
+    metadata: { labels: { app: backend } }
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: backend
+          image: {{ .Values.backend.image }}
+          ports: [{ containerPort: 3001 }]
+          envFrom:
+            - configMapRef: { name: sentri-config }
+            - secretRef: { name: sentri-secrets }
+          readinessProbe:
+            httpGet: { path: /api/v1/health, port: 3001 }
+          livenessProbe:
+            httpGet: { path: /api/v1/health, port: 3001 }

--- a/helm/sentri/templates/backend-service.yaml
+++ b/helm/sentri/templates/backend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sentri-backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001

--- a/helm/sentri/templates/configmap.yaml
+++ b/helm/sentri/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sentri-config
+data:
+  DATABASE_URL: {{ .Values.env.DATABASE_URL | quote }}
+  REDIS_URL: {{ .Values.env.REDIS_URL | quote }}
+  WORKER_CONCURRENCY: {{ .Values.env.WORKER_CONCURRENCY | quote }}

--- a/helm/sentri/templates/hpa.yaml
+++ b/helm/sentri/templates/hpa.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sentri-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sentri-worker
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Pods
+      pods:
+        metric: { name: app_queue_depth }
+        target: { type: AverageValue, averageValue: {{ .Values.autoscaling.targetQueueDepth | quote }} }
+{{- end }}

--- a/helm/sentri/templates/ingress.yaml
+++ b/helm/sentri/templates/ingress.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sentri
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sentri-backend
+                port:
+                  number: 3001
+{{- end }}

--- a/helm/sentri/templates/postgres-service.yaml
+++ b/helm/sentri/templates/postgres-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sentri-postgres
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/helm/sentri/templates/postgres-statefulset.yaml
+++ b/helm/sentri/templates/postgres-statefulset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sentri-postgres
+spec:
+  serviceName: sentri-postgres
+  selector: { matchLabels: { app: postgres } }
+  template:
+    metadata: { labels: { app: postgres } }
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          env:
+            - name: POSTGRES_PASSWORD
+              value: sentri
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources: { requests: { storage: {{ .Values.postgres.storage }} } }

--- a/helm/sentri/templates/redis-deployment.yaml
+++ b/helm/sentri/templates/redis-deployment.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sentri-redis
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: redis } }
+  template:
+    metadata: { labels: { app: redis } }
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports: [{ containerPort: 6379 }]

--- a/helm/sentri/templates/redis-service.yaml
+++ b/helm/sentri/templates/redis-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sentri-redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379

--- a/helm/sentri/templates/secret.yaml
+++ b/helm/sentri/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sentri-secrets
+type: Opaque
+stringData:
+  JWT_SECRET: {{ .Values.secrets.JWT_SECRET | quote }}
+  ENCRYPTION_KEY: {{ .Values.secrets.ENCRYPTION_KEY | quote }}

--- a/helm/sentri/templates/worker-deployment.yaml
+++ b/helm/sentri/templates/worker-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sentri-worker
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector: { matchLabels: { app: worker } }
+  template:
+    metadata: { labels: { app: worker } }
+    spec:
+      containers:
+        - name: worker
+          image: {{ .Values.worker.image }}
+          env:
+            - name: WORKER_HEALTH_PORT
+              value: {{ .Values.worker.healthPort | quote }}
+          envFrom:
+            - configMapRef: { name: sentri-config }
+            - secretRef: { name: sentri-secrets }
+          readinessProbe:
+            httpGet: { path: /healthz, port: {{ .Values.worker.healthPort }} }
+          livenessProbe:
+            httpGet: { path: /healthz, port: {{ .Values.worker.healthPort }} }

--- a/helm/sentri/values.yaml
+++ b/helm/sentri/values.yaml
@@ -1,0 +1,29 @@
+backend:
+  image: ghcr.io/example/sentri-backend:latest
+  replicas: 1
+worker:
+  image: ghcr.io/example/sentri-worker:latest
+  replicas: 1
+  healthPort: 3002
+postgres:
+  image: postgres:16
+  storage: 10Gi
+redis:
+  image: redis:7
+  cluster:
+    enabled: false
+ingress:
+  enabled: true
+  host: sentri.local
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetQueueDepth: 10
+env:
+  DATABASE_URL: postgres://sentri:sentri@sentri-postgres:5432/sentri
+  REDIS_URL: redis://sentri-redis:6379
+  WORKER_CONCURRENCY: "2"
+secrets:
+  JWT_SECRET: change-me
+  ENCRYPTION_KEY: change-me

--- a/tests/helm/values-overrides.yaml
+++ b/tests/helm/values-overrides.yaml
@@ -1,0 +1,3 @@
+ingress:
+  enabled: true
+  host: test.local


### PR DESCRIPTION
### Motivation
- Provide an initial production-grade Kubernetes deployment artefact (Helm chart) and probe wiring to let operators run Sentri on K8s with readiness/liveness probes.
- Expose a worker-local health endpoint so the worker Deployment can be probed independently of the web backend and flip readiness on Redis/BullMQ failures.
- Add a nightly Postgres backup workflow and an operator-facing disaster recovery runbook so RTO/RPO targets are documented and backups are automated.

### Description
- Added a new `helm/sentri/` chart with `Chart.yaml`, `values.yaml`, and templates for `backend`/`worker` Deployments, Postgres StatefulSet, Redis Deployment, `ConfigMap`, `Secret`, `Ingress`, and `HPA` (`helm/sentri/*`).
- Implemented a worker-side HTTP health endpoint in `backend/src/worker.js` that listens on `WORKER_HEALTH_PORT` (default `3002`) and returns `200` when the worker is ready and `503` otherwise, and wired the health server into graceful shutdown.
- Added CI workflow scaffolding: ` .github/workflows/helm-validate.yml` to render+validate Helm manifests and `.github/workflows/nightly-backup.yml` to run `pg_dump` and upload daily snapshots to S3, plus `tests/helm/values-overrides.yaml` for validation.
- Added operator docs and metadata updates: `docs/guide/disaster-recovery.md`, `docs/guide/kubernetes-deployment.md`, updated `docs/guide/env-vars.md`, appended an `INF-009` entry to `docs/changelog.md`, and extended `QA.md` with INF-009 checklist items.

### Testing
- Ran a static Node check with `node --check backend/src/worker.js`, which passed.
- Attempted to run `helm template helm/sentri --set ingress.host=test.local` locally but the environment lacked `helm`, so render/validation could not be executed here (the new `helm-validate` Action will run on PRs).
- No new unit/integration tests were added in this scaffold; follow-up work includes adding automated tests for the worker `/healthz` and completing the Helm/kind smoke tests listed in the acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f55bcca0083269e34e7bc83ff6b41)