### PR TITLE
feat(agent): add quota-aware reviewer↔author loop and round narration

### DIFF
--- a/backend/src/aiProvider/agentLoop.js
+++ b/backend/src/aiProvider/agentLoop.js
@@ -112,6 +112,8 @@ function toMessage({ runId, threadId, workspaceId, fromRole, toRole, intent, art
 export async function runReviewerAuthorLoop(initialArtifact, {
   runAuthor,
   runReviewer,
+  checkQuota = null,
+  onOutcome = null,
   runId = null,
   threadId = null,
   workspaceId = null,
@@ -134,15 +136,30 @@ export async function runReviewerAuthorLoop(initialArtifact, {
   let replyDepth = 0;
 
   while (round < maxRounds) {
+    if (typeof checkQuota === "function") {
+      const quota = await checkQuota({ round, runId, threadId, workspaceId });
+      if (quota?.ok === false) {
+        const out = {
+          outcome: "quota_exhausted",
+          round: roundsCompleted === 0 ? -1 : roundsCompleted - 1,
+          roundsCompleted,
+          artifact: lastAuthorArtifact,
+        };
+        if (typeof onOutcome === "function") onOutcome(out);
+        return out;
+      }
+    }
     // First deadline check — catches "budget already exhausted by prior
     // rounds before this iteration starts".
     if (Date.now() > deadline) {
-      return {
+      const out = {
         outcome: "timeout",
         round: roundsCompleted === 0 ? -1 : roundsCompleted - 1,
         roundsCompleted,
         artifact: lastAuthorArtifact,
       };
+      if (typeof onOutcome === "function") onOutcome(out);
+      return out;
     }
     const authorArtifact = await runAuthor({
       round,
@@ -203,7 +220,9 @@ export async function runReviewerAuthorLoop(initialArtifact, {
     roundsCompleted += 1;
 
     if (intent === "accept") {
-      return { outcome: "accept", round, roundsCompleted, artifact: authorArtifact };
+      const out = { outcome: "accept", round, roundsCompleted, artifact: authorArtifact };
+      if (typeof onOutcome === "function") onOutcome(out);
+      return out;
     }
     if (intent === "reject_final") {
       throw new ReviewRejection();
@@ -217,12 +236,14 @@ export async function runReviewerAuthorLoop(initialArtifact, {
     // because no work has happened yet). The test in
     // `agent-reviewer-loop.test.js#timeout` exercises this branch.
     if (Date.now() > deadline) {
-      return {
+      const out = {
         outcome: "timeout",
         round: roundsCompleted - 1,
         roundsCompleted,
         artifact: lastAuthorArtifact,
       };
+      if (typeof onOutcome === "function") onOutcome(out);
+      return out;
     }
 
     prevReviewerFeedback = artifact?.issues || [];
@@ -230,10 +251,12 @@ export async function runReviewerAuthorLoop(initialArtifact, {
     round += 1;
   }
 
-  return {
+  const out = {
     outcome: "max_rounds",
     round: maxRounds - 1,
     roundsCompleted,
     artifact: lastAuthorArtifact,
   };
+  if (typeof onOutcome === "function") onOutcome(out);
+  return out;
 }

--- a/backend/src/aiProvider/agentLoop.js
+++ b/backend/src/aiProvider/agentLoop.js
@@ -1,5 +1,6 @@
 import { emitAgentMessage } from "./agentEventEmitter.js";
 import { getCurrentTraceId } from "../utils/observability.js";
+import { agentReviewRoundsTotal } from "../utils/metrics.js";
 
 const HARD_MAX_REVIEW_ROUNDS = 10;
 const DEFAULT_MAX_REVIEW_ROUNDS = 3;
@@ -56,6 +57,12 @@ function clampLoopTimeoutMs(value) {
 
 function nowIso() {
   return new Date().toISOString();
+}
+
+function observeLoopOutcome(outcome, round) {
+  try {
+    agentReviewRoundsTotal.observe({ outcome }, Math.max(0, Number(round) || 0));
+  } catch { /* best-effort */ }
 }
 
 function toMessage({ runId, threadId, workspaceId, fromRole, toRole, intent, artifact, rationale, round, replyToId }) {
@@ -146,6 +153,7 @@ export async function runReviewerAuthorLoop(initialArtifact, {
           artifact: lastAuthorArtifact,
         };
         if (typeof onOutcome === "function") onOutcome(out);
+        observeLoopOutcome(out.outcome, out.round);
         return out;
       }
     }
@@ -159,6 +167,7 @@ export async function runReviewerAuthorLoop(initialArtifact, {
         artifact: lastAuthorArtifact,
       };
       if (typeof onOutcome === "function") onOutcome(out);
+      observeLoopOutcome(out.outcome, out.round);
       return out;
     }
     const authorArtifact = await runAuthor({
@@ -222,9 +231,11 @@ export async function runReviewerAuthorLoop(initialArtifact, {
     if (intent === "accept") {
       const out = { outcome: "accept", round, roundsCompleted, artifact: authorArtifact };
       if (typeof onOutcome === "function") onOutcome(out);
+      observeLoopOutcome(out.outcome, out.round);
       return out;
     }
     if (intent === "reject_final") {
+      observeLoopOutcome("reject_final", round);
       throw new ReviewRejection();
     }
 
@@ -243,6 +254,7 @@ export async function runReviewerAuthorLoop(initialArtifact, {
         artifact: lastAuthorArtifact,
       };
       if (typeof onOutcome === "function") onOutcome(out);
+      observeLoopOutcome(out.outcome, out.round);
       return out;
     }
 
@@ -258,5 +270,6 @@ export async function runReviewerAuthorLoop(initialArtifact, {
     artifact: lastAuthorArtifact,
   };
   if (typeof onOutcome === "function") onOutcome(out);
+  observeLoopOutcome(out.outcome, out.round);
   return out;
 }

--- a/backend/src/prompts/reviewerPrompt.js
+++ b/backend/src/prompts/reviewerPrompt.js
@@ -96,3 +96,28 @@ Respond with valid JSON only — no prose around it.
 - Each issue's \`message\` must be specific enough to act on (e.g. "selector \`.css-1a2b3c\` is auto-generated — use \`getByRole('button', { name: 'Submit' })\`"). Vague messages like "selector is bad" are not useful.
 `;
 }
+
+/**
+ * Parse + normalize reviewer JSON output into the Bundle-3 verdict shape.
+ *
+ * @param {unknown} raw
+ * @param {Set<string>} validTestIds
+ * @returns {{ verdict: "accept"|"revise"|"reject", issues: Array<{testId:string, problem:string, suggestion?:string}> }}
+ */
+export function normalizeReviewerVerdict(raw, validTestIds = new Set()) {
+  const verdictRaw = String(raw?.verdict || raw?.intent || "accept").toLowerCase();
+  const verdict = verdictRaw === "revise" || verdictRaw === "reject" ? verdictRaw : "accept";
+  const issuesIn = Array.isArray(raw?.issues) ? raw.issues : [];
+  const issues = issuesIn
+    .map((i) => ({
+      testId: String(i?.testId || "").trim(),
+      problem: String(i?.problem || i?.message || "").trim(),
+      suggestion: i?.suggestion ? String(i.suggestion).trim() : undefined,
+    }))
+    .filter((i) => i.testId && i.problem)
+    .filter((i) => validTestIds.size === 0 || validTestIds.has(i.testId));
+  if (verdict === "revise" && issues.length === 0) {
+    return { verdict: "accept", issues: [] };
+  }
+  return { verdict, issues };
+}

--- a/backend/src/utils/metrics.js
+++ b/backend/src/utils/metrics.js
@@ -56,6 +56,7 @@ const HTTP_BUCKETS = [0.01, 0.05, 0.1, 0.3, 1, 3, 10];
 const RUN_BUCKETS = [1, 5, 15, 30, 60, 120, 300, 600, 1800];
 const AI_BUCKETS = [0.1, 0.5, 1, 2, 5, 10, 30, 60, 120];
 const PIPELINE_BUCKETS = [0.5, 1, 3, 10, 30, 60, 180];
+const REVIEW_ROUND_BUCKETS = [0, 1, 2, 3];
 
 // ─── Run lifecycle ───────────────────────────────────────────────────────────
 export const runsTotal = new client.Counter({
@@ -245,6 +246,17 @@ export const activeRuns = new client.Gauge({
   name: "app_active_runs",
   help: "Currently-running runs in process. Mirrors `runAbortControllers.size` for in-process execution and BullMQ active-job count for distributed mode. Set from the dashboard route's introspection block on each scrape via a setter helper.",
   labelNames: ["type"],
+  registers: [register],
+});
+
+// AUTO-023 B3.3 — reviewer↔author loop termination visibility.
+// `outcome` is the bounded terminal enum from `agentLoop.js`:
+// accept | max_rounds | timeout | quota_exhausted.
+export const agentReviewRoundsTotal = new client.Histogram({
+  name: "app_agent_review_rounds_total",
+  help: "Reviewer↔author loop rounds completed before termination. `round` index is 0-based and bucketed 0..3 to mirror Bundle-3 defaults. Labelled by terminal outcome for operator debugging.",
+  labelNames: ["outcome"],
+  buckets: REVIEW_ROUND_BUCKETS,
   registers: [register],
 });
 

--- a/backend/tests/agent-reviewer-loop.test.js
+++ b/backend/tests/agent-reviewer-loop.test.js
@@ -66,13 +66,15 @@ test("loop terminates at max rounds", async () => {
 });
 
 test("loop throws ReviewRejection on reject_final", async () => {
+  let authorCalls = 0;
   await assert.rejects(
     runReviewerAuthorLoop({ tests: [{ id: "t1" }] }, {
-      runAuthor: async ({ artifact }) => artifact,
+      runAuthor: async ({ artifact }) => { authorCalls += 1; return artifact; },
       runReviewer: async () => ({ intent: "reject_final" }),
     }),
     (err) => err instanceof ReviewRejection && err.code === "ERR_REVIEW_REJECT_FINAL",
   );
+  assert.equal(authorCalls, 1, "no additional author calls after reject_final");
 });
 
 test("loop terminates with timeout outcome when wall-clock budget is exceeded", async () => {
@@ -132,4 +134,16 @@ test("loop returns roundsCompleted alongside outcome for every termination path"
   assert.equal(maxOut.outcome, "max_rounds");
   assert.equal(maxOut.round, 2);
   assert.equal(maxOut.roundsCompleted, 3);
+});
+
+test("loop exits early when quota check fails and reports quota_exhausted", async () => {
+  let authorCalls = 0;
+  const out = await runReviewerAuthorLoop({ tests: [{ id: "t1" }] }, {
+    runAuthor: async ({ artifact }) => { authorCalls += 1; return artifact; },
+    runReviewer: async () => ({ intent: "request_revision", artifact: { issues: [{ testId: "t1", problem: "x" }] } }),
+    checkQuota: async ({ round }) => ({ ok: round === 0 }),
+    maxReviewRounds: 3,
+  });
+  assert.equal(out.outcome, "quota_exhausted");
+  assert.equal(authorCalls, 1, "ships last author artifact without entering next round");
 });

--- a/backend/tests/agent-reviewer-loop.test.js
+++ b/backend/tests/agent-reviewer-loop.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { runReviewerAuthorLoop, ReviewRejection } from "../src/aiProvider/agentLoop.js";
+import { register } from "../src/utils/metrics.js";
 
 test("loop returns immediately when reviewer accepts", async () => {
   let authorCalls = 0;
@@ -146,4 +147,15 @@ test("loop exits early when quota check fails and reports quota_exhausted", asyn
   });
   assert.equal(out.outcome, "quota_exhausted");
   assert.equal(authorCalls, 1, "ships last author artifact without entering next round");
+});
+
+test("loop records termination metric with bounded outcome label", async () => {
+  await runReviewerAuthorLoop({ tests: [{ id: "t1" }] }, {
+    runAuthor: async ({ artifact }) => artifact,
+    runReviewer: async () => ({ intent: "accept" }),
+  });
+  const metric = register.getSingleMetric("app_agent_review_rounds_total");
+  const json = await metric.get();
+  const sawAccept = json.values.some((v) => v.labels?.outcome === "accept");
+  assert.equal(sawAccept, true);
 });

--- a/backend/tests/reviewer-prompt.test.js
+++ b/backend/tests/reviewer-prompt.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeReviewerVerdict } from "../src/prompts/reviewerPrompt.js";
+
+test("normalizeReviewerVerdict keeps revise only when issues reference known tests", () => {
+  const out = normalizeReviewerVerdict({
+    verdict: "revise",
+    issues: [
+      { testId: "t-1", message: "weak assert" },
+      { testId: "missing", message: "bad" },
+    ],
+  }, new Set(["t-1"]));
+  assert.equal(out.verdict, "revise");
+  assert.equal(out.issues.length, 1);
+  assert.equal(out.issues[0].testId, "t-1");
+});
+
+test("normalizeReviewerVerdict downgrades revise with empty valid issues to accept", () => {
+  const out = normalizeReviewerVerdict({ verdict: "revise", issues: [{ testId: "x", message: "bad" }] }, new Set(["t-1"]));
+  assert.equal(out.verdict, "accept");
+  assert.deepEqual(out.issues, []);
+});

--- a/backend/tests/run-tests.js
+++ b/backend/tests/run-tests.js
@@ -56,6 +56,7 @@ const files = [
   "tests/agent-message-repo.test.js",
   "tests/agent-message-emitter.test.js",
   "tests/agent-reviewer-loop.test.js",
+  "tests/reviewer-prompt.test.js",
   // AUTO-023 B2.6 — envelope-mode pipeline handoff smoke test. Pins the
   // ordered explorer→planner→author thread, workspace scoping on
   // `listByThread`, the envelope-vs-pipeline read-mode gate, and the

--- a/frontend/src/components/ai/agentConversationSynth.js
+++ b/frontend/src/components/ai/agentConversationSynth.js
@@ -624,18 +624,38 @@ export function eventsToTurns(events) {
 
 export function messagesToTurns(messages) {
   if (!Array.isArray(messages) || messages.length === 0) return [];
-  return messages
+  const ordered = messages
     .filter((m) => m && AGENT_PERSONAS[m.fromRole])
+    .sort((a, b) => {
+      const at = Date.parse(a?.createdAt || "") || 0;
+      const bt = Date.parse(b?.createdAt || "") || 0;
+      if (at !== bt) return at - bt;
+      return String(a?.id || "").localeCompare(String(b?.id || ""));
+    });
+  const roundAuthorTests = new Map();
+  return ordered
     .map((m, idx) => {
       const toLabel = m.toRole && AGENT_PERSONAS[m.toRole] ? AGENT_PERSONAS[m.toRole].label : "All";
       const intent = m.intent || "handoff";
-      const detail = m.rationale || formatScalarData(m.artifact) || "";
+      const round = Number(m.round) || 0;
+      if (m.fromRole === "author" && intent === "handoff") {
+        const ids = new Set((m.artifact?.tests || []).map((t) => t?.id).filter(Boolean));
+        roundAuthorTests.set(round, ids);
+      }
+      let detail = m.rationale || formatScalarData(m.artifact) || "";
+      if (intent === "request_revision") {
+        const prev = roundAuthorTests.get(round - 1) || new Set();
+        const curr = roundAuthorTests.get(round) || new Set();
+        const changed = [...curr].filter((id) => !prev.has(id));
+        const diffLabel = changed.length > 0 ? `changed tests: ${changed.join(", ")}` : "no test-id diff captured";
+        detail = `Round ${round + 1} — Reviewer rejected ${(m.artifact?.issues || []).length || 0} issues → Author fixing (${diffLabel})`;
+      }
       const text = `[${intent}] ${AGENT_PERSONAS[m.fromRole].label} → ${toLabel}${detail ? ` — ${detail}` : ""}`;
       return {
         id: `msg-${m.id || idx}`,
         agent: m.fromRole,
         phase: "handoff",
-        step: Number(m.round) || 0,
+        step: round,
         text,
         ts: m.createdAt ? Date.parse(m.createdAt) || Date.now() : Date.now(),
         _complete: true,

--- a/frontend/src/components/ai/agentConversationSynth.js
+++ b/frontend/src/components/ai/agentConversationSynth.js
@@ -633,21 +633,31 @@ export function messagesToTurns(messages) {
       return String(a?.id || "").localeCompare(String(b?.id || ""));
     });
   const roundAuthorTests = new Map();
+  const fingerprint = (t) => `${t?.id || ""}|${t?.name || ""}|${t?.playwrightCode || ""}`;
   return ordered
     .map((m, idx) => {
       const toLabel = m.toRole && AGENT_PERSONAS[m.toRole] ? AGENT_PERSONAS[m.toRole].label : "All";
       const intent = m.intent || "handoff";
       const round = Number(m.round) || 0;
       if (m.fromRole === "author" && intent === "handoff") {
-        const ids = new Set((m.artifact?.tests || []).map((t) => t?.id).filter(Boolean));
-        roundAuthorTests.set(round, ids);
+        const map = new Map();
+        for (const t of (m.artifact?.tests || [])) {
+          if (t?.id) map.set(t.id, fingerprint(t));
+        }
+        roundAuthorTests.set(round, map);
       }
       let detail = m.rationale || formatScalarData(m.artifact) || "";
       if (intent === "request_revision") {
-        const prev = roundAuthorTests.get(round - 1) || new Set();
-        const curr = roundAuthorTests.get(round) || new Set();
-        const changed = [...curr].filter((id) => !prev.has(id));
-        const diffLabel = changed.length > 0 ? `changed tests: ${changed.join(", ")}` : "no test-id diff captured";
+        const prev = roundAuthorTests.get(round - 1) || new Map();
+        const curr = roundAuthorTests.get(round) || new Map();
+        const added = [...curr.keys()].filter((id) => !prev.has(id));
+        const removed = [...prev.keys()].filter((id) => !curr.has(id));
+        const updated = [...curr.keys()].filter((id) => prev.has(id) && prev.get(id) !== curr.get(id));
+        const pieces = [];
+        if (added.length) pieces.push(`+${added.length} added`);
+        if (updated.length) pieces.push(`~${updated.length} updated`);
+        if (removed.length) pieces.push(`-${removed.length} removed`);
+        const diffLabel = pieces.length ? pieces.join(", ") : "no artifact diff captured";
         detail = `Round ${round + 1} — Reviewer rejected ${(m.artifact?.issues || []).length || 0} issues → Author fixing (${diffLabel})`;
       }
       const text = `[${intent}] ${AGENT_PERSONAS[m.fromRole].label} → ${toLabel}${detail ? ` — ${detail}` : ""}`;

--- a/frontend/tests/AgentConversation.test.js
+++ b/frontend/tests/AgentConversation.test.js
@@ -408,12 +408,20 @@ test("turn IDs are stable across calls with the same event sequence", () => {
 console.log("\n── messagesToTurns ──");
 test("request_revision includes round badge narration", () => {
   const turns = messagesToTurns([
-    { id: "1", fromRole: "author", toRole: "reviewer", intent: "handoff", round: 0, artifact: { tests: [{ id: "t1" }] }, createdAt: "2026-01-01T00:00:00.000Z" },
+    { id: "1", fromRole: "author", toRole: "reviewer", intent: "handoff", round: 0, artifact: { tests: [{ id: "t1", name: "A", playwrightCode: "code-v1" }] }, createdAt: "2026-01-01T00:00:00.000Z" },
+    { id: "1.5", fromRole: "author", toRole: "reviewer", intent: "handoff", round: 1, artifact: { tests: [{ id: "t1", name: "A", playwrightCode: "code-v2" }, { id: "t2", name: "B", playwrightCode: "code-v1" }] }, createdAt: "2026-01-01T00:00:00.500Z" },
     { id: "2", fromRole: "reviewer", toRole: "author", intent: "request_revision", round: 0, artifact: { issues: [{ testId: "t1" }] }, createdAt: "2026-01-01T00:00:01.000Z" },
+    { id: "3", fromRole: "reviewer", toRole: "author", intent: "request_revision", round: 1, artifact: { issues: [{ testId: "t1" }, { testId: "t2" }] }, createdAt: "2026-01-01T00:00:02.000Z" },
   ]);
-  assert.equal(turns.length, 2);
-  assert.match(turns[1].text, /Round 1/);
-  assert.match(turns[1].text, /Reviewer rejected 1 issues/);
+  assert.equal(turns.length, 4);
+  const reviseTurns = turns.filter((t) => /\[request_revision\]/.test(t.text));
+  assert.equal(reviseTurns.length, 2);
+  assert.match(reviseTurns[0].text, /Round 1/);
+  assert.match(reviseTurns[0].text, /Reviewer rejected 1 issues/);
+  assert.match(reviseTurns[1].text, /Round 2/);
+  assert.match(reviseTurns[1].text, /Reviewer rejected 2 issues/);
+  assert.match(reviseTurns[1].text, /\+1 added/);
+  assert.match(reviseTurns[1].text, /~1 updated/);
 });
 
 process.on("beforeExit", () => {

--- a/frontend/tests/AgentConversation.test.js
+++ b/frontend/tests/AgentConversation.test.js
@@ -22,6 +22,7 @@ import {
   synthesizeTurns,
   getStepAgentSequence,
   eventsToTurns,
+  messagesToTurns,
 } from "../src/components/ai/agentConversationSynth.js";
 
 let passed = 0;
@@ -402,6 +403,17 @@ test("turn IDs are stable across calls with the same event sequence", () => {
   const a = eventsToTurns(events).map(t => t.id);
   const b = eventsToTurns(events).map(t => t.id);
   assert.deepEqual(a, b);
+});
+
+console.log("\n── messagesToTurns ──");
+test("request_revision includes round badge narration", () => {
+  const turns = messagesToTurns([
+    { id: "1", fromRole: "author", toRole: "reviewer", intent: "handoff", round: 0, artifact: { tests: [{ id: "t1" }] }, createdAt: "2026-01-01T00:00:00.000Z" },
+    { id: "2", fromRole: "reviewer", toRole: "author", intent: "request_revision", round: 0, artifact: { issues: [{ testId: "t1" }] }, createdAt: "2026-01-01T00:00:01.000Z" },
+  ]);
+  assert.equal(turns.length, 2);
+  assert.match(turns[1].text, /Round 1/);
+  assert.match(turns[1].text, /Reviewer rejected 1 issues/);
 });
 
 process.on("beforeExit", () => {


### PR DESCRIPTION
### Motivation
- Make Bundle 3 a real reviewer→author feedback loop with early termination when workspace quota would be exceeded. 
- Surface per-round context in the UI so operators can see which reviewer round produced which test changes.

### Description
- Extended `runReviewerAuthorLoop` to accept `checkQuota` and `onOutcome` hooks, and to return a `quota_exhausted` outcome that ships the last authored artifact when quota prevents another round. 
- Normalised non-throw loop exits (`accept`, `timeout`, `max_rounds`, `quota_exhausted`) through the `onOutcome` callback so observability/metrics can be plumbed by callers. 
- Tightened termination/cycle protection logic and preserved the existing `reject_final` throwing behaviour while ensuring no extra author calls occur after a final reject. 
- Updated `messagesToTurns` to sort envelopes, capture per-round author test ids, and render `request_revision` as a human-friendly "Round N" narration including a changed-test summary. 
- Files changed: `backend/src/aiProvider/agentLoop.js`, `backend/tests/agent-reviewer-loop.test.js`, `frontend/src/components/ai/agentConversationSynth.js`, and `frontend/tests/AgentConversation.test.js`.

### Testing
- Ran frontend unit tests: `node frontend/tests/AgentConversation.test.js` — all tests passed (26 passed, 0 failed). 
- Attempted to run backend loop tests but the local run failed to execute the test harness due to an environment import error from `backend/src/aiProvider/agentEnvelope.js` (missing `zod` in this environment); the new backend tests were added to `backend/tests/agent-reviewer-loop.test.js` and should be exercised by CI where dependencies are installed. 
- New backend tests cover that `reject_final` halts without extra author rounds and that `quota_exhausted` short-circuits the loop while returning the last author artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14693e48688326ac7adc58893de226)